### PR TITLE
Forgotten leftover of a makepdf option

### DIFF
--- a/bin/makepdf
+++ b/bin/makepdf
@@ -177,7 +177,7 @@ function build_manuals()
     fi
 }
 
-while getopts ":hcdmn:l:" o
+while getopts ":hcdmn:" o
 do
     case ${o} in
         d )


### PR DESCRIPTION
Option `-l` no longer present and removed (in sync with docs)

Backports to 2.7 and 2.8