### PR TITLE
Update supported platforms for clients 2.8.1

### DIFF
--- a/modules/ROOT/pages/installing.adoc
+++ b/modules/ROOT/pages/installing.adoc
@@ -20,9 +20,9 @@ You will also find links to source code archives and older versions on the downl
 * macOS 10.12+ (x86-64 or Apple M in Rosetta 2 emulation; unsupported legacy builds for Mac OS X 10.10 & 10.11 available)
 * CentOS 7.6+ & 8 (x86-64)
 * Debian 9.0 & 10 (x86-64)
-* Fedora 30 & 31 & 32 (x86-64)
-* Ubuntu 18.04 & 19.04 & 19.10 & 20.04 (x86-64)
-* openSUSE Leap 15.0 & 15.1 & 15.2 (x86-64)
+* Fedora 31 & 32 & 33 (x86-64)
+* Ubuntu 18.04 & 20.04 & 20.10 & 21.04 (x86-64)
+* openSUSE Leap 15.1 & 15.2 (x86-64)
 
 NOTE: For Linux distributions, we support, if technically feasible, the latest 2 versions per platform and the previous Ubuntu https://wiki.ubuntu.com/LTS[LTS].
 


### PR DESCRIPTION
References: https://github.com/owncloud/client/pull/8662

Backporting to 2.8