### PR TITLE
Update to the find orphaned scripts

### DIFF
--- a/bin/find-orphaned-attachment-files
+++ b/bin/find-orphaned-attachment-files
@@ -16,10 +16,10 @@ for manual in "${AVAILABLE_MANUAL[@]}"; do
     [[ ! -e "./modules/${manual}/" ]] && echo "Cannot find ${manual} manual." && continue
 
     echo -e "\e[1;32mChecking the ${manual} manual \e[0m"
-    find "./modules/${manual}/examples/" \
+    find "./modules/${manual}/assets/attachments/" \
         \( -path "**/.DS_Store" -o -path "**/vendor" -o -path "**/.gitkeep" \) -prune -o \
         -type f \
-        -exec bash -c 'grep -rnq -E "include:.*$(basename $0 | sed "s/\./\\./")" ./modules/$1/pages || echo "$0"' {} "${manual}" \;
+        -exec bash -c 'grep -rnq -E "link:.*$(basename $0 | sed "s/\./\\./")" ./modules/$1/pages || echo "$0"' {} "${manual}" \;
     echo
 done
 

--- a/bin/find-orphaned-image-files
+++ b/bin/find-orphaned-image-files
@@ -16,10 +16,10 @@ for manual in "${AVAILABLE_MANUAL[@]}"; do
     [[ ! -e "./modules/${manual}/" ]] && echo "Cannot find ${manual} manual." && continue
 
     echo -e "\e[1;32mChecking the ${manual} manual \e[0m"
-    find "./modules/${manual}/examples/" \
+    find "./modules/${manual}/assets/images/" \
         \( -path "**/.DS_Store" -o -path "**/vendor" -o -path "**/.gitkeep" \) -prune -o \
         -type f \
-        -exec bash -c 'grep -rnq -E "include:.*$(basename $0 | sed "s/\./\\./")" ./modules/$1/pages || echo "$0"' {} "${manual}" \;
+        -exec bash -c 'grep -rnq -E "image:.*$(basename $0 | sed "s/\./\\./")" ./modules/$1/pages || echo "$0"' {} "${manual}" \;
     echo
 done
 


### PR DESCRIPTION
Updates following find-orphaned* scripts:

`find-orphaned-image-files`
`find-orphaned-example-files`
`find-orphaned-attachment-files`

Backport to 2.8 and 2.7