### PR TITLE
makepdf: add option for error output

### DIFF
--- a/bin/makepdf
+++ b/bin/makepdf
@@ -18,6 +18,7 @@ IFS=$'\n\t'
 
 ACTION=
 VERSION=
+FAILURE_LEVEL=
 DEFAULT_VERSION="master"
 DRY_RUN=false
 FONTS_DIRECTORY="fonts"
@@ -43,6 +44,19 @@ YMLFILE="$DIR/../site.yml"
 
 source $DIR/yamlparse.sh
 
+# if we are working local without drone, get the actual branch the pdf build is made for.
+# the correct branch name will be printed when the pdf is created.
+# check if git is present
+if command -v git &> /dev/null; then
+    # check if we are on a branch and get the name if we are on one
+    if currentbranch=$(git symbolic-ref --short -q HEAD)
+    then
+        DEFAULT_VERSION=${currentbranch}
+    else
+        DEFAULT_VERSION='No Branch'
+    fi
+fi
+
 if [[ -z "${VERSION:-}" ]]; then
     if [[ -n "${DRONE_TAG:-}" ]]; then
         VERSION=${DRONE_TAG/v//}
@@ -57,6 +71,7 @@ function usage()
     echo "Usage: ./bin/makepdf [-c] [-d] [-h] [-m] [-n <${AVAILABLE_MANUAL}>]"
     echo
     echo "-h ... help"
+    echo "-e ... Set failure level to ERROR (default: FATAL)"
     echo "-c ... clean the build/ directory (contains the pdf)"
     echo "-d ... Debug mode, prints the book to be converted. Only in combination with -m and/or -n"
     echo "-m ... Build all available manuals"
@@ -125,7 +140,7 @@ function build_pdf_manual()
         return 0
     fi
 
-    echo "Generating version '${revision}' of the ${SPEAKING_NAME} manual, dated: ${release_date}"
+    echo "Generating the ${manual} manual from branch '${revision}', dated: ${release_date}"
     mkdir -p "$build_directory"
 
     # https://docs.asciidoctor.org/asciidoctor.js/latest/cli/options/
@@ -158,8 +173,8 @@ function build_pdf_manual()
 #    cat $book_file <(convert_antora_nav_to_asciidoc_list "$nav_file")
 #    exit
 
-    createpdf="asciidoctor-pdf $param - < <(cat $book_file <(convert_antora_nav_to_asciidoc_list "$nav_file"))"
-#   createpdf="asciidoctor-pdf $param - < <(cat $book_file)"
+    createpdf="asciidoctor-pdf $FAILURE_LEVEL $param - < <(cat $book_file <(convert_antora_nav_to_asciidoc_list "$nav_file"))"
+#   createpdf="asciidoctor-pdf $FAILURE_LEVEL $param - < <(cat $book_file)"
 
 	eval $createpdf
 
@@ -177,7 +192,7 @@ function build_manuals()
     fi
 }
 
-while getopts ":hcdmn:" o
+while getopts ":hecdmn:" o
 do
     case ${o} in
         d )
@@ -191,6 +206,9 @@ do
             ;;
         c )
             ACTION="CLEAN"
+            ;;
+        e )
+            FAILURE_LEVEL='--failure-level=ERROR'
             ;;
         : )
             echo "Invalid option: $OPTARG requires an argument" 1>&2


### PR DESCRIPTION
Add an option to set the log-level to ERROR for printing errors (default would be FATAL only)

Backport to 2.7 and 2.8

@xoxys fyi