### PR TITLE
Fix Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@
 
 The Desktop Client documentation is not built independently. Instead, it is built together with the [server documentation](https://github.com/owncloud/docs/). However, you can build a local copy of the desktop client documentation to preview changes you are making.
 
-Whenever a Pull Request of this repo gets merged, it automaticaly triggers a full docs build.
+Whenever a Pull Request of this repo gets merged, it automatically triggers a full docs build.
 
 ## General Notes
 
-To make life easier, most of the content written in [docs](https://github.com/owncloud/docs#readme) applies also here. For ease of reading, the most important steps are documented here too. For more information see the link provided. Only few topics of this repo are unique like the branching.
+To make life easier, most of the content written in [docs](https://github.com/owncloud/docs#readme) applies also here. For ease of reading, the most important steps are documented here too. For more information see the link provided. Only a few topics of this repo are unique like the branching.
 
 ## Prepare Your Environment
 
@@ -48,4 +48,4 @@ Please refer to the [Branching Workflow for the Desktop Client](https://github.c
 
 ## Create a New Version Branch for the Desktop Client
 
-Please refer to [Create a New Version Branch for the Desktop Client](https://github.com/owncloud/docs-client-desktop/blob/master/docs/new-version-branch.md) or more information.
+Please refer to [Create a New Version Branch for the Desktop Client](https://github.com/owncloud/docs-client-desktop/blob/master/docs/new-version-branch.md) for more information.

--- a/README.md
+++ b/README.md
@@ -2,21 +2,29 @@
 
 ## Building the Docs
 
-The desktop client documentation is not built independently. Instead, it is built together with the [core documentation](https://github.com/owncloud/docs/). However, you can build a local copy of the desktop client documentation to preview changes you are making.
+The Desktop Client documentation is not built independently. Instead, it is built together with the [server documentation](https://github.com/owncloud/docs/). However, you can build a local copy of the desktop client documentation to preview changes you are making.
+
+Whenever a Pull Request of this repo gets merged, it automaticaly triggers a full docs build.
+
+## General Notes
+
+To make life easier, most of the content written in [docs](https://github.com/owncloud/docs#readme) applies also here. For ease of reading, the most important steps are documented here too. For more information see the link provided. Only a view topics of this repo are unique like the branching.
 
 ## Prepare Your Environment
 
-To prepare your local environment, clone this repository and run
+To prepare your local environment, some steps need to be made:
+
+1.) Have the [necessary prerequisites](https://github.com/owncloud/docs/blob/master/docs/build-the-docs.md#install-the-prerequisites) installed.
+
+2.) Clone this repository and run
 ```
 yarn install
 ```
 to setup all necessary dependencies.
 
-**Note**, these commands require NodeJS and Yarn to be installed. To learn more about how to install them, refer to the [documentation in the docs repository](https://github.com/owncloud/docs/blob/master/docs/getting-started.md).
+## Building the Desktop Client Documentation
 
-## Building the Client Documentation
-
-Run the following command to build the client documentation
+Run the following command to build the client documentation locally
 
 ```
 yarn antora-local
@@ -24,8 +32,20 @@ yarn antora-local
 
 ## Previewing the Generated Docs
 
-Assuming that there are no build errors, the next thing to do is to view the result in your browser. In case you have already installed a web server, you need to configure a virtual host (or similar) which points to the directory `public/`, located in the `docs/` directory of this repository. This directory contains the generated documentation. Alternatively, use the simple server bundled with the current package.json, just execute the following command to serve the documentation at [http://localhost:8080/desktop/](http://localhost:8080/desktop/):
+Assuming that there are no build errors, the next thing to do is to view the result in your browser. In case you have already installed a web server to access local pages, you need to configure a virtual host (or similar) which points to the directory `public/`, located in the root directory of this repository. This directory contains the generated documentation. Alternatively, use the simple web server `serve` bundled with the current package.json, just execute the following command to serve the documentation at [http://localhost:8080/desktop/](http://localhost:8080/desktop/):
 
 ```
 yarn serve
 ```
+
+## Target Branch and Backporting
+
+See the the [following section](https://github.com/owncloud/docs#target-branch-and-backporting) as the same rules and notes apply.
+
+## Branching Workflow
+
+Please refer to the [Branching Workflow for the Desktop Client](https://github.com/owncloud/docs-client-desktop/blob/master/docs/the-branching-workflow.md) or more information.
+
+## Create a New Version Branch for the Desktop Client
+
+Please refer to [Create a New Version Branch for the Desktop Client](https://github.com/owncloud/docs-client-desktop/blob/master/docs/new-version-branch.md) or more information.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Whenever a Pull Request of this repo gets merged, it automaticaly triggers a ful
 
 ## General Notes
 
-To make life easier, most of the content written in [docs](https://github.com/owncloud/docs#readme) applies also here. For ease of reading, the most important steps are documented here too. For more information see the link provided. Only a view topics of this repo are unique like the branching.
+To make life easier, most of the content written in [docs](https://github.com/owncloud/docs#readme) applies also here. For ease of reading, the most important steps are documented here too. For more information see the link provided. Only few topics of this repo are unique like the branching.
 
 ## Prepare Your Environment
 

--- a/docs/new-version-branch.md
+++ b/docs/new-version-branch.md
@@ -1,0 +1,38 @@
+# Create a New Version Branch for Desktop
+
+When doing a new release for the Desktop Client like `2.x`, a new version branch must be created based on `master`. It is necessary to do this in four steps. Please set the new and former version numbers accordingly
+
+**Step 1: Create and configure the new `2.x` branch**
+
+1.  Create a new `2.x` branch based on latest `origin/master`
+2.  Copy the `.drone.star` file from the _former_ `2.x-1` branch
+    (it contains the correct branch specific setup rules and replaces the current one coming from master)
+3.  In `.drone.star` set `latest_version` to `2.x` (on top in section `def main(ctx)`)
+4.  In `site.yml` adjust all `-version` keys according the new and former releases
+    (in section `asciidoc.attributes`)
+5.  In `antora.yml` change the version from `master` to `2.x`
+6.  Run a build by entering `yarn antora-local`. No errors should occur
+7.  Commit the changes and push the new `2.x` branch. **DO NOT CREATE A PR!**
+
+**Step 2: Configure the master branch to use the new `2.x` branch**
+
+9.  Create a new `changes_necessary_for_2.x` branch based on latest `origin/master`
+10.  In `.drone.star` set `latest_version` to `2.x` (on top in section `def main(ctx)`)
+11. In `site.yml` adjust all `-version` keys according the new and former releases
+    (in section `asciidoc.attributes`)
+12. No changes in `antora.yml` but check if the version is set to `master`
+13. Run a build by entering `yarn antora-local`. No errors should occur
+14. Commit changes and push it
+15. Create a Pull Request. When CI is green, all is done correctly. Merge the PR to master.
+
+**Step 3: Set the correct Desktop build branches in the docs repo**
+
+16. In `site.yml` of [docs](https://github.com/owncloud/docs/blob/master/site.yml) adjust the last **two** branches at `url: https://github.com/owncloud/docs-client-desktop.git` accordingly
+    (in section `content.sources.url.branches`)
+
+**Step 4: Protection and Renaming**
+
+17. Go to the settings of the this repository and change the protection of the branch list (Settings > Branches) so that
+    the `2.x` branch gets protected and the `2.x-2` branch is no longer protected.
+18. Rename the `2.x-2` branch to `x_archived_2.x-2`
+

--- a/docs/the-branching-workflow.md
+++ b/docs/the-branching-workflow.md
@@ -1,0 +1,5 @@
+# The Branching Workflow
+
+Only three branches are maintained at any one time; these are `master` and two for the current Client Desktop release. Any change to the documentation is made in a branch based off of `master`. Once the branch's PR is approved and merged, the PR is backported to the branch for the **current** Desktop release and the **former** release but only if it applies to it.
+
+When a new ownCloud major or minor Desktop version is released, a new branch is created to track the changes for that release. The branch for the oldest release freezes, take off the active maintained branch list is no longer maintained.

--- a/docs/the-branching-workflow.md
+++ b/docs/the-branching-workflow.md
@@ -1,5 +1,5 @@
 # The Branching Workflow
 
-Only three branches are maintained at any one time; these are `master` and two for the current Client Desktop release. Any change to the documentation is made in a branch based off of `master`. Once the branch's PR is approved and merged, the PR is backported to the branch for the **current** Desktop release and the **former** release but only if it applies to it.
+Only three branches are maintained at any one time; these are `master`, the current, and the former Client Desktop release series. Any change to the documentation is made in a branch based off of `master`. Once the branch's PR is approved and merged, the PR is backported to the branch for the **current** Desktop release and the **former** release but only if it applies to it.
 
 When a new ownCloud major or minor Desktop version is released, a new branch is created to track the changes for that release. The branch for the oldest release freezes, take off the active maintained branch list is no longer maintained.

--- a/docs/the-branching-workflow.md
+++ b/docs/the-branching-workflow.md
@@ -2,4 +2,4 @@
 
 Only three branches are maintained at any one time; these are `master`, the current, and the former Client Desktop release series. Any change to the documentation is made in a branch based off of `master`. Once the branch's PR is approved and merged, the PR is backported to the branch for the **current** Desktop release and the **former** release but only if it applies to it.
 
-When a new ownCloud major or minor Desktop version is released, a new branch is created to track the changes for that release. The branch for the oldest release freezes, take off the active maintained branch list is no longer maintained.
+When a new ownCloud major or minor Desktop version is released, a new branch is created to track the changes for that release. The branch for the oldest release is frozen, taken off the active maintained branch list and is no longer maintained.


### PR DESCRIPTION
Fixes readme.md to reflect the current build changes, notes and how to setup new version branches propely.

Should be backported to 2.7 and 2.8

When this PR gets merged, we can use this repo as template for the other clients.

@xoxys you may be interestend in the new version branch setup giude: `docs/new-version-branch.md`