### PR TITLE
Fix site.yml 2.8 and master

### DIFF
--- a/modules/ROOT/pages/appendices/building.adoc
+++ b/modules/ROOT/pages/appendices/building.adoc
@@ -228,12 +228,12 @@ craft --install-deps owncloud-client
 craft --fetch owncloud-client
 ----
 
-You can find the git checkout in `C:\CraftRoot\downloads\git\owncloud\owncloud-client`. There you can use the usual git commands to switch branches and remotes, e.g., to build the `{latest-version}` stable branch you can use craft with --set version parameter:
+You can find the git checkout in `C:\CraftRoot\downloads\git\owncloud\owncloud-client`. There you can use the usual git commands to switch branches and remotes, e.g., to build the `{latest-desktop-version}` stable branch you can use craft with --set version parameter:
 
 [source,powershell,subs="attributes+"]
 ----
-git checkout {latest-version}
-craft --set version={latest-version} owncloud-client
+git checkout {latest-desktop-version}
+craft --set version={latest-desktop-version} owncloud-client
 ----
 
 Afterwards you can build the client like this:

--- a/site.yml
+++ b/site.yml
@@ -23,8 +23,12 @@ asciidoc:
     idprefix: ''
     idseparator: '-'
     experimental: ''
+    # delete block
     latest-version: 2.8
     previous-version: 2.7
+    # delete block
+    latest-desktop-version: 2.8
+    previous-desktop-version: 2.7
   extensions:
     - ./lib/extensions/tabs.js
     - ./node_modules/asciidoctor-kroki/src/asciidoctor-kroki.js


### PR DESCRIPTION
We have "confusing" variable names as they are used in many repos and if there are errors raising during compilation, we do not know which doc is the origin of the error.

Backport to 2.8 only, 2.7 will get a own PR for this.