### PR TITLE
Remove unused site.yml variables in 2.7

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -23,10 +23,6 @@ asciidoc:
     idprefix: ''
     idseparator: '-'
     experimental: ''
-    # delete block
-    latest-version: 2.7
-    previous-version: 2.6
-    # delete block
     latest-desktop-version: 2.7
     previous-desktop-version: 2.6
   extensions:


### PR DESCRIPTION
Remove unused site.yml variables for 2.7

No backport, as master and 2.8 have their own PR