### PR TITLE
generic build instructions should use python3-sphinx

### DIFF
--- a/modules/ROOT/pages/appendices/building.adoc
+++ b/modules/ROOT/pages/appendices/building.adoc
@@ -74,7 +74,7 @@ To get the source dependencies on Debian and Ubuntu, run the following command:
 [source,console]
 ----
 sudo apt install qtdeclarative5-dev libinotifytools-dev \
-  qt5keychain-dev python-sphinx \
+  qt5keychain-dev python3-sphinx \
   libsqlite3-dev
 ----
 ====


### PR DESCRIPTION
on ubuntu 20.04 pyhton-sqhinx no longer exists.