### PR TITLE
Alternate method for moving the sync folder

### DIFF
--- a/modules/ROOT/pages/faq.adoc
+++ b/modules/ROOT/pages/faq.adoc
@@ -2,15 +2,15 @@
 :toc: right
 :toclevels: 1
 
-== Some Files Are Continuously Uploaded To The Server, Even When They Are Not Modified
+== Some Files Are Continuously Uploaded to the Server, Even When They Are Not Modified
 
-It is possible that another program is changing the modification date of the file. If the file is uses the `.eml` extension, Windows automatically and continually changes all files, unless you remove. 
+It is possible that another program is changing the modification date of the file. If the file has an `.eml` extension, Windows automatically and continually changes the file, unless you remove it. 
 `\HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\PropertySystem\PropertyHandlers`
 from the windows registry. See
 http://petersteier.wordpress.com/2011/10/22/windows-indexer-changes-modification-dates-of-eml-files/
 for more information.
 
-== Syncing Stops When Attempting To Sync Deeper Than 100 Sub-directories
+== Syncing Stops When Attempting to Sync Deeper Than 100 Sub-Directories
 
 The sync client has been intentionally limited to sync no deeper than 100 sub-directories. The hard limit exists to guard against bugs with cycles like symbolic link loops. When a deeply nested directory is excluded from synchronization it will be listed with other ignored files and directories in the "Not synced" tab of the "Activity" pane.
 
@@ -22,23 +22,23 @@ The ownCloud Desktop Client talks to a server, e.g. the ownCloud server, so you 
 
 image:oc-unsupported-version-warning-message.png[image,width=60%]
 
-=== Because earlier versions are not maintained anymore, only ownCloud 10.0.0 or higher is supported 
+=== Because Earlier Versions Are Not Maintained Anymore, Only ownCloud 10.0.0 or Higher Is Supported 
 
 So if you encounter such a message, you should ask your administrator to upgrade ownCloud to a secure version. An important feature of the ownCloud Client is checksumming – each time you download or upload a file, the client and the server both check if the file was corrupted during the sync. This way you can be sure that you don’t lose any files.
 
 There are servers out there which don’t have checksumming implemented on their side, or which are not tested by ownCloud’s QA team. They can’t ensure file integrity, they have potential security issues, and we can’t guarantee that they are compatible with the ownCloud Desktop Client.
 
-=== We care about your data and want it to be safe
+=== We Care About Your Data and Want It to Be Safe
 
 That’s why you see this warning message, so you can evaluate your data security. Don’t worry – you can still use the client with an unsupported server, but do so at your own risk.
 
-== There Was A Warning About Changes In Synchronized Folders Not Being Tracked Reliably
+== There Was a Warning About Changes in Synchronized Folders Not Being Tracked Reliably
 
-On Linux when the synchronized folder contains very many subfolders the operating system may not allow for enough `inotify` watches to monitor the changes in all of them.
+On Linux, when the synchronized folder contains a high number of subfolders, the operating system may not allow for enough `inotify` watches to monitor the changes in all of them.
 
 In this case the client will not be able to immediately start the synchronization process when a file in one of the unmonitored folders changes. Instead, the client will show the warning and manually scan folders for changes in a regular interval (two hours by default).
 
-This problem can be solved by setting the `fs.inotify.max_user_watches sysctl` to a higher value. This can usually be done either temporarily:
+This problem can be solved by setting the `fs.inotify.max_user_watches sysctl` to a higher value and can usually be done either temporarily:
 
 [source]
 ----
@@ -47,42 +47,55 @@ echo 524288 > /proc/sys/fs/inotify/max_user_watches.
 
 or permanently by adjusting `/etc/sysctl.conf`.
 
-== I Want To Move My Local Sync Folder
+== I Want to Move My Local Sync Folder
 
-The ownCloud desktop client does not provide a way to change the local sync directory. However, it can be done, though it is a bit unorthodox. Specifically, you have to:
+The ownCloud desktop client does not provide a way to change the local sync folder directly. However, it can be done in two ways:
 
-1.  Remove the existing connection which syncs to the wrong directory.
-2.  Add a new connection which syncs to the desired directory.
+. Copy the folder and avoid a full re-sync:
 
+.. Stop the client and edit the `localPath=` line in the
+xref:advanced_usage/configuration_file.adoc#location-of-the-configuration-file[configuration file]
+according your needs.
+
+.. Copy (or move) all your data from the current to the new location manually and start the client.
+
+. Create a new sync connection with a new location: 
+
+..  Remove the existing connection which syncs to the old directory.
++
+To do so, in the client UI, which you can see below, click the drop down menu menu:Account[Remove].
++
 image:setup/ownCloud-remove_existing_connection.png[image,width=60%]
-
-To do so, in the client UI, which you can see above, click the "*Account*" drop-down menu and then click "Remove". This will display a "*Confirm Account Removal*" dialog window.
-
++
+This will display a "*Confirm Account Removal*" dialog window. If you're sure, click btn:[Remove connection].
++
 image:setup/ownCloud-remove_existing_connection_confirmation_dialog.png[image,width=60%]
 
-If you're sure, click "*Remove connection*". Then, click the Account drop-down menu again, and this time click "*Add new*".
-
-image:setup/ownCloud-replacement_connection_wizard.png[image,width=60%]
-
-This opens the ownCloud Connection Wizard, which you can see above, _but_ with an extra option. This option provides the ability to either keep the existing data (synced by the previous connection) or to start a clean sync (erasing the existing data).
-
+..  Add a new connection which syncs to the desired directory.
++
+Click the drop-down menu menu:Account[Add new].
++
+This opens the ownCloud Connection Wizard, which you can see below, _but_ with an extra option. This option provides the ability to either keep the existing data _(synced by the previous connection)_ or to start a clean sync _(erasing the existing data)_.
++
 [IMPORTANT]
 ====
 Be careful before choosing the "Start a clean sync" option. The old sync folder _may_ contain a considerable amount of data, ranging into the gigabytes or terabytes. If it does, after the client creates the new connection, it will have to download *all* of that information again.
 
 Instead, first move or copy the old local sync folder, containing a copy of the existing files, to the new location. Then, when creating the new connection choose "_keep existing data_" instead. The ownCloud client will check the files in the newly-added sync folder and find that they match what is on the server and not need to download anything.
 ====
++
+image:setup/ownCloud-replacement_connection_wizard.png[image,width=60%]
++
+Make your choice and click btn:[Connect...] This will then lead you through the Connection Wizard, just like when you set up the previous sync connection, but giving you the opportunity to choose a new sync directory.
 
-Make your choice and click "*Connect...*" This will then step you through the Connection Wizard, just as you did when you setup the previous sync connection, but giving you the opportunity to choose a new sync directory.
-
-== I Want To Change My Server Url
+== I Want to Change My Server URL
 
 Since changing server urls is a potentially dangerous operation the ownCloud desktop client does not provide a user interface for this change. Typically, server url changes should be implemented by serving a permanent redirect to the new location on the old url. The client will then permanently update the server url the next time it queries the old url.
 
 For situations where arranging for a redirect is impossible, url changes can be done by editing the config file. Before doing so make sure that the new url does indeed point to the same server, with the same users and the same data. Then go through these steps:
 
 1. Shut down the ownCloud client.
-2. Locate the configuration file. It's usually located in `AppData/Roaming/ownCloud/owncloud.cfg` on Windows or `~/.config/ownCloud/owncloud.cfg` on Linux.
+2. Locate the xref:advanced_usage/configuration_file.adoc#location-of-the-configuration-file[configuration file]
 3. Open it with a text editor.
 4. Find your old server url and adjust it.
 5. Save the file and start the ownCloud client again.


### PR DESCRIPTION
It is also possible to move manually (a) as a full re-sync (b) may not always be desirable.
the instructions in a) are intentionally terse, so that novice users would rather choose b).