### PR TITLE
Page alias for build instructions

### DIFF
--- a/modules/ROOT/pages/appendices/building.adoc
+++ b/modules/ROOT/pages/appendices/building.adoc
@@ -11,6 +11,7 @@
 :qt-download-url: http://www.qt.io/download
 :openssl-windows-build-url: http://slproweb.com/products/Win32OpenSSL.html
 :qtkeychain-url: https://github.com/frankosterfeld/qtkeychain
+:page-aliases: building.adoc
 
 This section explains how to build link:https://owncloud.org/download/#owncloud-desktop-client[the ownCloud Client] from source for all major platforms.
 You should read this section if you want to develop for the desktop client.


### PR DESCRIPTION
potential solution for https://github.com/owncloud/client/issues/8990

I tried it locally:

```
% curl http://localhost:8080/desktop/next/building.html
<!DOCTYPE html>
<meta charset="utf-8">
<link rel="canonical" href="https://doc.owncloud.com/desktop/next/appendices/building.html">
<script>location="appendices/building.html"</script>
<meta http-equiv="refresh" content="0; url=appendices/building.html">
<meta name="robots" content="noindex">
<title>Redirect Notice</title>
<h1>Redirect Notice</h1>
<p>The page you requested has been relocated to <a href="appendices/building.html">https://doc.owncloud.com/desktop/next/appendices/building.html</a>.</p>
```