### PR TITLE
Changes necessary for the 2.9 branch

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -6,7 +6,7 @@ def main(ctx):
     # Version shown as latest in generated documentations
     # It's fine that this is out of date in version branches, usually just needs
     # adjustment in master/deployment_branch when a new version is added to site.yml
-    latest_version = "2.8"
+    latest_version = "2.9"
     default_branch = "master"
 
     # Current version branch (used to determine when changes are supposed to be pushed)

--- a/site.yml
+++ b/site.yml
@@ -23,8 +23,8 @@ asciidoc:
     idprefix: ''
     idseparator: '-'
     experimental: ''
-    latest-desktop-version: 2.8
-    previous-desktop-version: 2.7
+    latest-desktop-version: 2.9
+    previous-desktop-version: 2.8
   extensions:
     - ./lib/extensions/tabs.js
     - ./node_modules/asciidoctor-kroki/src/asciidoctor-kroki.js


### PR DESCRIPTION
The 2.9 branch has been created based on master, adopted and pushed.

These are the changes in master so that the actual branch is set to 2.9

Post merging:
* the 2.7 branch will be renamed and archived according the process described in docs.
* in docs, the desktop releases + pdf links are checked/adopted to the branches available

NO BACKPORTING !!