### PR TITLE
Add note for password on BACKEND_HOST

### DIFF
--- a/modules/ROOT/pages/appendices/guitest.adoc
+++ b/modules/ROOT/pages/appendices/guitest.adoc
@@ -80,7 +80,7 @@ Some necessary steps before running tests:
 . Clone the {client-repo-url}[Desktop Client] from GitHub
 . Copy `test/gui/config.sample.ini` to `test/suite_oc-desktop/config.ini`
 . Edit `test/gui/config.ini` and set `BACKEND_HOST=` to the URL of your ownCloud server, e.g. `BACKEND_HOST=http://localhost/owncloud-core`
-
++
 NOTE: BACKEND_HOST can be any server, but it is required that the password for the user `admin` is set to `admin`.
 
 . Start Squish

--- a/modules/ROOT/pages/appendices/guitest.adoc
+++ b/modules/ROOT/pages/appendices/guitest.adoc
@@ -80,6 +80,9 @@ Some necessary steps before running tests:
 . Clone the {client-repo-url}[Desktop Client] from GitHub
 . Copy `test/gui/config.sample.ini` to `test/suite_oc-desktop/config.ini`
 . Edit `test/gui/config.ini` and set `BACKEND_HOST=` to the URL of your ownCloud server, e.g. `BACKEND_HOST=http://localhost/owncloud-core`
+
+NOTE: BACKEND_HOST can be any server but it's required that password for user 'admin' is set to 'admin'
+
 . Start Squish
 . Open the existing test-suite via: menu:File[Open Test Suite > test/gui]
 . Go to menu:Edit[Server Settings > Manage AUTs > Mapped AUTs]

--- a/modules/ROOT/pages/appendices/guitest.adoc
+++ b/modules/ROOT/pages/appendices/guitest.adoc
@@ -81,7 +81,7 @@ Some necessary steps before running tests:
 . Copy `test/gui/config.sample.ini` to `test/suite_oc-desktop/config.ini`
 . Edit `test/gui/config.ini` and set `BACKEND_HOST=` to the URL of your ownCloud server, e.g. `BACKEND_HOST=http://localhost/owncloud-core`
 
-NOTE: BACKEND_HOST can be any server but it's required that password for user 'admin' is set to 'admin'
+NOTE: BACKEND_HOST can be any server, but it is required that the password for the user `admin` is set to `admin`.
 
 . Start Squish
 . Open the existing test-suite via: menu:File[Open Test Suite > test/gui]


### PR DESCRIPTION
Add the hint for account settings on BACKEND_HOST, see https://github.com/owncloud/client/issues/8841#issuecomment-889034155