### PR TITLE
add more page aliases for pages now in appendices folder

### DIFF
--- a/modules/ROOT/pages/appendices/architecture.adoc
+++ b/modules/ROOT/pages/appendices/architecture.adoc
@@ -2,6 +2,7 @@
 :toc: right
 :toclevels: 1
 :theopengroup-url: http://pubs.opengroup.org/onlinepubs/009695399/utilities/xcu_chap02.html#tag_02_13_01
+:page-aliases: architecture.adoc
 
 == Introduction
 

--- a/modules/ROOT/pages/appendices/troubleshooting.adoc
+++ b/modules/ROOT/pages/appendices/troubleshooting.adoc
@@ -2,6 +2,7 @@
 :toc: right
 :toclevels: 1
 :files-antivirus-app-url: https://github.com/owncloud/files_antivirus
+:page-aliases: troubleshooting.adoc
 
 == Introduction
 


### PR DESCRIPTION
During migration in separate repo, some pages were moved in `appendices` subfolder. This broke some already published links. After moving of pages, `:page-aliases:` feature should be used. (related: https://github.com/owncloud/docs-client-desktop/pull/100)