### PR TITLE
Fix pdf image size

### DIFF
--- a/modules/ROOT/pages/appendices/building.adoc
+++ b/modules/ROOT/pages/appendices/building.adoc
@@ -13,6 +13,8 @@
 :qtkeychain-url: https://github.com/frankosterfeld/qtkeychain
 :page-aliases: building.adoc
 
+== Introduction
+
 This section explains how to build link:https://owncloud.org/download/#owncloud-desktop-client[the ownCloud Client] from source for all major platforms.
 You should read this section if you want to develop for the desktop client.
 Build instructions are subject to change as development proceeds.

--- a/modules/ROOT/pages/appendices/troubleshooting.adoc
+++ b/modules/ROOT/pages/appendices/troubleshooting.adoc
@@ -71,7 +71,7 @@ Client log files contain file and folder names, metadata, server URLs and other 
 +
 The Log Output window opens.
 +
-image:log_output_window.png[image,width=60%]
+image:log_output_window.png[image,width=60%,pdfwidth=60%]
 +
 .  Enable the btn:[Enable logging to temporary folder] checkbox.
 .  Later, to find the log files, click the btn:[Open folder] button.

--- a/modules/ROOT/pages/faq.adoc
+++ b/modules/ROOT/pages/faq.adoc
@@ -20,7 +20,7 @@ Keeping software up to date is crucial for file integrity and security – if so
 
 The ownCloud Desktop Client talks to a server, e.g. the ownCloud server, so you don’t only have to upgrade your client when there is a new version for it, also the server has to be kept up-to-date by your sysadmin. Starting with version 2.5.0, the client will show a warning message if you connect to an outdated or unsupported server:
 
-image:oc-unsupported-version-warning-message.png[image,width=60%]
+image:oc-unsupported-version-warning-message.png[image,width=60%,pdfwidth=60%]
 
 === Because Earlier Versions Are Not Maintained Anymore, Only ownCloud 10.0.0 or Higher Is Supported 
 
@@ -65,11 +65,11 @@ according your needs.
 +
 To do so, in the client UI, which you can see below, click the drop down menu menu:Account[Remove].
 +
-image:setup/ownCloud-remove_existing_connection.png[image,width=60%]
+image:setup/ownCloud-remove_existing_connection.png[image,width=60%,pdfwidth=60%]
 +
 This will display a "*Confirm Account Removal*" dialog window. If you're sure, click btn:[Remove connection].
 +
-image:setup/ownCloud-remove_existing_connection_confirmation_dialog.png[image,width=60%]
+image:setup/ownCloud-remove_existing_connection_confirmation_dialog.png[image,width=60%,pdfwidth=60%]
 
 ..  Add a new connection which syncs to the desired directory.
 +
@@ -84,7 +84,7 @@ Be careful before choosing the "Start a clean sync" option. The old sync folder 
 Instead, first move or copy the old local sync folder, containing a copy of the existing files, to the new location. Then, when creating the new connection choose "_keep existing data_" instead. The ownCloud client will check the files in the newly-added sync folder and find that they match what is on the server and not need to download anything.
 ====
 +
-image:setup/ownCloud-replacement_connection_wizard.png[image,width=60%]
+image:setup/ownCloud-replacement_connection_wizard.png[image,width=60%,pdfwidth=60%]
 +
 Make your choice and click btn:[Connect...] This will then lead you through the Connection Wizard, just like when you set up the previous sync connection, but giving you the opportunity to choose a new sync directory.
 

--- a/modules/ROOT/pages/installing.adoc
+++ b/modules/ROOT/pages/installing.adoc
@@ -187,15 +187,15 @@ msiexec /i ownCloud-x.y.z.msi DO_NOT_SCHEDULE_REBOOT="1"
 
 The installation wizard takes you step-by-step through configuration options and account setup. First you need to enter the URL of your ownCloud server.
 
-image:client-1.png[form for entering ownCloud server URL,width=60%]
+image:client-1.png[form for entering ownCloud server URL,width=60%,pdfwidth=60%]
 
 Enter your ownCloud login on the next screen.
 
-image:client-2.png[form for entering your ownCloud login,width=60%]
+image:client-2.png[form for entering your ownCloud login,width=60%,pdfwidth=60%]
 
 On the _"Local Folder Option"_ screen you may sync all of your files on the ownCloud server, or select individual folders. The default local sync folder is `ownCloud`, in your home directory. You may change this as well.
 
-image:client-3.png[Select which remote folders to sync, and which local folder to store them in,width=60%]
+image:client-3.png[Select which remote folders to sync, and which local folder to store them in,width=60%,pdfwidth=60%]
 
 When you have completed selecting your sync folders, click the _"Connect"_ button at the bottom right. The client will attempt to connect to your ownCloud server, and when it is successful you'll see two buttons:
 

--- a/modules/ROOT/pages/navigating.adoc
+++ b/modules/ROOT/pages/navigating.adoc
@@ -37,7 +37,7 @@ The red circle with the white "x" indicates a configuration error, such as an in
 
 A right-click on the systray icon opens a menu for quick access to multiple operations.
 
-image:menu.png[image,width=30%]
+image:menu.png[image,width=30%,pdfwidth=30%]
 
 This menu provides the following options:
 
@@ -52,7 +52,7 @@ This menu provides the following options:
 
 A left-click on your systray icon opens the desktop client to the account settings window.
 
-image:client6.png[image,width=60%]
+image:client6.png[image,width=60%,pdfwidth=60%]
 
 === Configuring ownCloud Account Settings
 
@@ -75,7 +75,7 @@ The little button with three dots (the overflow menu) that sits to the right of 
 
 *Pause Sync* pauses sync operations without making any changes to your account. It will continue to update file and folder lists, without downloading or updating files. To stop all sync activity use **Remove Folder Sync Connection**.
 
-image:client-7.png[image]
+image:client-7.png[image,pdfwidth=40%]
 
 NOTE: ownCloud does not preserve the mtime (modification time) of directories, though it does update the mtimes on files. See https://github.com/owncloud/core/issues/7009:[Wrong folder date when syncing] for discussion of this.
 
@@ -110,15 +110,15 @@ If a directory includes ignored files that are marked with warning icons that do
 
 The ownCloud desktop sync client integrates with your file manager: Finder on Mac OS X, Explorer on Windows, and Nautilus on Linux. (Linux users must install the `owncloud-client-nautilus` plugin.) You can create share links, and share with internal ownCloud users the same way as in your ownCloud Web interface.
 
-image:mac-share.png[image,width=60%]
+image:mac-share.png[image,width=60%,pdfwidth=60%]
 
 Right-click your systray icon, hover over the account you want to use, and left-click  menu:Open folder["folder name"] to quickly enter your local ownCloud folder. Right-click the file or folder you want to share to expose the share dialog, and click menu:Share with ownCloud[].
 
-image:share-1.png[image,width=30%]
+image:share-1.png[image,width=40%,pdfwidth=40%]
 
 The share dialog has all the same options as your ownCloud Web interface.
 
-image:share-2.png[image,width=50%]
+image:share-2.png[image,width=50%,pdfwidth=50%]
 
 Use *Share with ownCloud* to see who you have shared with, and to modify their permissions, or to delete the share.
 
@@ -126,7 +126,7 @@ Use *Share with ownCloud* to see who you have shared with, and to modify their p
 
 The Activity window contains the log of your recent activities, organized over three tabs: *Server Activities*, which includes new shares and files downloaded and deleted, *Sync Protocol*, which displays local activities such as which local folders your files went into, and. *Not Synced* shows errors such as files not synced. Double clicking an entry pointing to an existing file in *Server Activities* or *Sync Protocol* will open the folder containing the file and highlight it.
 
-image:client-8.png[image,width=60%]
+image:client-8.png[image,width=60%,pdfwidth=60%]
 
 == Server Notifications
 
@@ -135,7 +135,7 @@ Starting with version 2.2.0, the client will display notifications from your own
 The desktop client automatically checks for available notifications automatically on a regular basis. Notifications are displayed in the Server Activity tab, and if you have *Show Desktop Notifications*.
 enabled (General tab) you'll also see a systray notification.
 
-image:client12.png[image,width=60%]
+image:client12.png[image,width=60%,pdfwidth=60%]
 
 This also displays notifications sent to users by the ownCloud admin via the Announcements app.
 
@@ -143,7 +143,7 @@ This also displays notifications sent to users by the ownCloud admin via the Ann
 
 The General window has configuration options such as "_Launch on System Startup_", "_Use Monochrome Icons_", and "_Show Desktop Notifications_". This is where you will find the "_Edit Ignored Files_" button, to launch the ignored files editor, and "_Ask confirmation before downloading folders larger than [folder size]_".
 
-image:client-9.png[image,width=60%]
+image:client-9.png[image,width=60%,pdfwidth=60%]
 
 TIP: While you can elect whether to show or hide the crash reporter, from the General window, you can also configure whether to show or hide it from xref:advanced_usage/configuration_file.adoc#general-section[the general section of the configuration file] as well. Doing so can help with debugging on-startup-crashes.
 
@@ -153,7 +153,7 @@ proxy settings, SOCKS, bandwith, throttling, limiting.
 
 The Network settings window enables you to define network proxy settings, and also to limit download and upload bandwidth.
 
-image:settings_network.png[image,width=60%]
+image:settings_network.png[image,width=60%,pdfwidth=60%]
 
 == Using the Ignored Files Editor
 
@@ -161,7 +161,7 @@ Ignored files, exclude files, patterns.
 
 You might have some local files or directories that you do not want to backup and store on the server. To identify and exclude these files or directories, you can use the menu:General Tab[Ignored Files Editor]
 
-image:ignored_files_editor.png[image,width=40%]
+image:ignored_files_editor.png[image,width=40%,pdfwidth=40%]
 
 For your convenience, the editor is pre-populated with a default list of typical ignore patterns. These patterns are contained in a system file. (typically `sync-exclude.lst`) located in the ownCloud Client application directory. You cannot modify these pre-populated patterns directly from the editor. However, if necessary, you can hover over any pattern in the list to show the path and filename associated with that pattern, locate the file, and edit the `sync-exclude.lst` file.
 

--- a/modules/ROOT/pages/vfs.adoc
+++ b/modules/ROOT/pages/vfs.adoc
@@ -39,7 +39,7 @@ An empty representation of the file and only available if the sync service is av
 
 The following image demonstrates how the _full pinned_, _full_ and _placeholder_ file states are shown in File Explorer.
 
-image:vfs/vfs-ms-cloud-file-states-file-explorer.png[File States, width=50%]
+image:vfs/vfs-ms-cloud-file-states-file-explorer.png[File States, width=50%,pdfwidth=50%]
 
 === Limitations and Restrictions
 
@@ -65,21 +65,21 @@ To set up a new synchronization with virtual file system enabled, perform the fo
 
 . Add a new synchronization by clicking the btn:[+ Add account] button.
 +
-image:vfs/vfs-add account.png[Add Account, width=50%]
+image:vfs/vfs-add account.png[Add Account, width=50%,pdfwidth=50%]
 
 . Enter the server address and your credentials in the following dialogs.
 
 . Select the radio button btn:[Use virtual files] and set the local folder where your synchronization data will reside.
 +
-image:vfs/vfs-sync-type.png[Set the Sync Type, width=80%]
+image:vfs/vfs-sync-type.png[Set the Sync Type, width=80%,pdfwidth=80%]
 
 . When everything is done, you should see a similar screen as below, showing that the setup completed successfully.
 +
-image:vfs/vfs-setup-successful.png[Setup Successful, width=80%]
+image:vfs/vfs-setup-successful.png[Setup Successful, width=80%,pdfwidth=80%]
 
 . After the first sync, your synchronization folder will show your items with the _Placeholder_ icon.
 +
-image:vfs/vfs-setup-successful-explorer.png[Setup Successful Explorer, width=80%]
+image:vfs/vfs-setup-successful-explorer.png[Setup Successful Explorer, width=80%,pdfwidth=80%]
 
 . When opening a file, the file gets downloaded and its synchronization icon changes to _Full_.
 
@@ -89,7 +89,7 @@ If you have full synchronization enabled, you can change to a virtual file syste
 
 . Open your existing synchronization, click the btn:[...] button and menu:Enable virtual file support[].
 +
-image:vfs/vfs-convert-to-vfs.png[Convert Full to VFS, width=80%]
+image:vfs/vfs-convert-to-vfs.png[Convert Full to VFS, width=80%,pdfwidth=80%]
 
 . Your local files will get replaced by _placeholders_, thus freeing up the space previously occupied.
 
@@ -99,15 +99,15 @@ You can also change the synchronization setting from virtual file system to full
 
 . Open your existing synchronization, click the btn:[...] button and menu:Disable virtual file support[].
 +
-image:vfs/vfs-disable-virtual-file-support-1.png[Disable VFS 1, width=80%]
+image:vfs/vfs-disable-virtual-file-support-1.png[Disable VFS 1, width=80%,pdfwidth=80%]
 
 . A notification window will ask you to confirm before completing the conversion.
 +
-image:vfs/vfs-disable-virtual-file-support-2.png[Disable VFS 2, width=80%]
+image:vfs/vfs-disable-virtual-file-support-2.png[Disable VFS 2, width=80%,pdfwidth=80%]
 
 . When done, your files will be fully downloaded, which you can tell by the sync icons, see the example image below. Depending on the quantity and size of the files, this may take a while.
 +
-image:vfs/vfs-full-sync-no-vfs.png[Full Snyc No VFS, width=80%]
+image:vfs/vfs-full-sync-no-vfs.png[Full Snyc No VFS, width=80%,pdfwidth=80%]
 
 === Manage VFS from ownCloud
 
@@ -117,13 +117,13 @@ You can manage the synchronization for all files and folders via ownCloud. This 
 
 . Open your existing synchronization, click the btn:[...] button and menu:Availability[Make always available locally].
 +
-image:vfs/vfs-make-always-availabe.png[Make Iteams always Available, width=80%]
+image:vfs/vfs-make-always-availabe.png[Make Iteams always Available, width=80%,pdfwidth=80%]
 
 . When opening the Explorer, you will see that all files get the sync icon image:vfs/vfs-free-up-local-space-icon.png[Free Up Space Icon].
 +
-image:vfs/vfs-free-up-local-space-done.png[Free Up Space Done, width=80%]
+image:vfs/vfs-free-up-local-space-done.png[Free Up Space Done, width=80%,pdfwidth=80%]
 . The icon will change to _Full Pinned_ when downloaded.
-image:vfs/vfs-make-always-availabe-start-sync.png[Make Iteams always Available Start Sync, width=80%]
+image:vfs/vfs-make-always-availabe-start-sync.png[Make Iteams always Available Start Sync, width=80%,pdfwidth=80%]
 
 ==== Make All Files _Placeholders_
 
@@ -131,11 +131,11 @@ You can free up space by unpinning all files at once and making them placeholder
 
 . Open your existing synchronization, click the btn:[...] button and menu:Availability[Free up local space].
 +
-image:vfs/vfs-free-up-local-space.png[Free Up Space, width=80%]
+image:vfs/vfs-free-up-local-space.png[Free Up Space, width=80%,pdfwidth=80%]
 
 . When done, Explorer will show the files in _Placeholder_ state.
 +
-image:vfs/vfs-setup-successful-explorer.png[Setup Successful Explorer, width=80%]
+image:vfs/vfs-setup-successful-explorer.png[Setup Successful Explorer, width=80%,pdfwidth=80%]
 
 === Manage VFS from Windows Explorer
 
@@ -145,22 +145,22 @@ You can manage individual files in the Explorer window by menu:right-clicking[] 
  
 . To create a Full Pinned file (have a local copy of it), use the action btn:[Always keep on this device].
 +
-image:vfs/vfs-always-keep-on-this-device.png[Always keep on this Device, width=80%]
+image:vfs/vfs-always-keep-on-this-device.png[Always keep on this Device, width=80%,pdfwidth=80%]
 +
 The state of the file will change to synchronizing.
 +
-image:vfs/vfs-always-keep-on-this-device-syncing.png[Always keep on this Device Syncing, width=50%]
+image:vfs/vfs-always-keep-on-this-device-syncing.png[Always keep on this Device Syncing, width=50%,pdfwidth=50%]
 +
 When the local copy has been created, the state (icon) changes to _Full Pinned_.
 +
-image:vfs/vfs-always-keep-on-this-device-synced.png[Always keep on this Device Syned, width=50%]
+image:vfs/vfs-always-keep-on-this-device-synced.png[Always keep on this Device Syned, width=50%,pdfwidth=50%]
 
 ==== Free up Space of a File
 
 . To free up the space the file occupied, use the action btn:[Free up space].
 +
-image:vfs/vfs-free-up-space.png[Free Up Space, width=50%]
+image:vfs/vfs-free-up-space.png[Free Up Space, width=50%,pdfwidth=50%]
 
 . When done, Explorer will show the file in _Placeholder_ state.
 +
-image:vfs/vfs-setup-successful-explorer.png[Setup Successful Explorer, width=80%]
+image:vfs/vfs-setup-successful-explorer.png[Setup Successful Explorer, width=80%,pdfwidth=80%]


### PR DESCRIPTION
This PR fixes the image sizes for the pdf files, they were mostly much too small.
Now they are sized correctly.
A manual pdf creation and visual test shows them ok now.

Also fixed a missing introduction section header

Backporting to 2.9 and 2.8