### PR TITLE
Using release notes

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -18,3 +18,4 @@
 ** xref:appendices/architecture.adoc[History and Architecture]
 ** xref:appendices/troubleshooting.adoc[Troubleshooting]
 ** xref:appendices/guitest.adoc[GUI Testing the Desktop Client]
+** xref:appendices/release_notes.adoc[Release Notes]

--- a/modules/ROOT/pages/appendices/release_notes.adoc
+++ b/modules/ROOT/pages/appendices/release_notes.adoc
@@ -1,0 +1,6 @@
+= Release Notes
+:desktop-changelog-url: https://github.com/owncloud/client/blob/master/CHANGELOG.md
+
+== Changelog for the Desktop Client
+
+ownCloud provides a full changelog with a summary and details for each release of the Desktop Client. Click the following link to access it at {desktop-changelog-url}[GitHub].


### PR DESCRIPTION
Using release notes in the same way we have them in the Android docs, see : owncloud/docs-client-android#6 (Update release notes) and ios-app

Referencing the desktop version of course 😃

Backport to 2.9 and 2.8