### PR TITLE
remove outdated version numbers

### DIFF
--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -9,8 +9,6 @@ Available for Windows, Mac OS X, and various Linux distributions, the ownCloud D
 
 Your files are always automatically synchronized between your ownCloud server and local PC.
 
-Desktop Sync clients older than. 2.2.1 are not allowed to connect and sync with ownCloud 8.1+ server. It is highly recommended to keep your server and client updated.
-
 == Improvements and New Features
 
 Each release of the ownCloud Desktop Sync client has new features and improvements, for details see the https://owncloud.com/changelog/desktop/[complete changelog].


### PR DESCRIPTION
The client entry page should not feature client version 2.2.1 or server versions 8.1 both are horribly outdated.
Do we want to speak about supported versions here?

backport to 2.9 would be cool!