### PR TITLE
Part one fixing broken anchors (in- and inter-document references)

### DIFF
--- a/modules/ROOT/pages/appendices/architecture.adoc
+++ b/modules/ROOT/pages/appendices/architecture.adoc
@@ -136,7 +136,7 @@ By default, the ownCloud Client ignores the following files:
 * Windows only: Files with a trailing space or dot.
 * Windows only: Filenames that are reserved on Windows.
 
-If a pattern selected using a checkbox in the xref:visualtour.adoc#the-ignored-files-editor[Ignored Files Editor], or if a line in the exclude file starts with the character `]` directly followed by the file pattern, files matching the pattern are considered.
+If a pattern selected using a checkbox in the xref:navigating.adoc#Using-the-ignored-files-editor[Ignored Files Editor], or if a line in the exclude file starts with the character `]` directly followed by the file pattern, files matching the pattern are considered.
 
 *fleeting meta data*.
 

--- a/modules/ROOT/pages/navigating.adoc
+++ b/modules/ROOT/pages/navigating.adoc
@@ -85,7 +85,7 @@ You may configure multiple ownCloud accounts in your desktop sync client. Simply
 
 [NOTE]
 ====
-To use *Two-Factor Authentication* (2FA), ownCloud server must have {oauth2-app-url}[the OAuth2 app] installed, configured, and enabled. Please contact your ownCloud administrator for more details.
+To use *Two-Factor Authentication* (2FA), ownCloud server must have the {oauth2-app-url}[OAuth2 app] installed, configured, and enabled. Please contact your ownCloud administrator for more details.
 ====
 
 == File Manager Overlay Icons
@@ -160,7 +160,7 @@ The General window has configuration options such as "_Launch on System Startup_
 
 image:navigating/client-9.png[image, width=60%,pdfwidth=60%]
 
-TIP: While you can elect whether to show or hide the crash reporter, from the General window, you can also configure whether to show or hide it from xref:advanced_usage/configuration_file.adoc#general-section[the general section of the configuration file] as well. Doing so can help with debugging on-startup-crashes.
+TIP: While you can elect whether to show or hide the crash reporter, from the General window, you can also configure whether to show or hide it from the xref:advanced_usage/configuration_file.adoc#section-general[general section of the configuration file] as well. Doing so can help with debugging on-startup-crashes.
 
 == Using the Network Window
 


### PR DESCRIPTION
This is part one fixing broken anchors...

Backport to 2.9 and 2.8