### PR TITLE
Part three fixing broken anchors (in- and inter-document references)

### DIFF
--- a/modules/ROOT/pages/appendices/architecture.adoc
+++ b/modules/ROOT/pages/appendices/architecture.adoc
@@ -136,7 +136,7 @@ By default, the ownCloud Client ignores the following files:
 * Windows only: Files with a trailing space or dot.
 * Windows only: Filenames that are reserved on Windows.
 
-If a pattern selected using a checkbox in the xref:navigating.adoc#Using-the-ignored-files-editor[Ignored Files Editor], or if a line in the exclude file starts with the character `]` directly followed by the file pattern, files matching the pattern are considered.
+If a pattern selected using a checkbox in the xref:navigating.adoc#using-the-ignored-files-editor[Ignored Files Editor], or if a line in the exclude file starts with the character `]` directly followed by the file pattern, files matching the pattern are considered.
 
 *fleeting meta data*.
 


### PR DESCRIPTION
This is part three fixing broken anchors...
(fixing a upper/lower case typo)

Backport to 2.9 and 2.8

Note, part two was accidentially direct committed against 2.8 instead via a branch and by pushing, it got merged. See the following reference for changes (only one line) https://github.com/owncloud/docs-client-desktop/commit/00989eae5b7e8a9c2b8bd0f4699609afe4587156