### PR TITLE
update new branch doc

### DIFF
--- a/docs/new-version-branch.md
+++ b/docs/new-version-branch.md
@@ -20,7 +20,7 @@ When doing a new release for the Desktop Client like `2.x`, a new version branch
 10.  In `.drone.star` set `latest_version` to `2.x` (on top in section `def main(ctx)`)
 11. In `site.yml` adjust all `-version` keys according the new and former releases
     (in section `asciidoc.attributes`)
-12. No changes in `antora.yml` but check if the version is set to `master`
+12. No changes in `antora.yml` but check if the version is set to `next`
 13. Run a build by entering `yarn antora-local`. No errors should occur
 14. Commit changes and push it
 15. Create a Pull Request. When CI is green, all is done correctly. Merge the PR to master.
@@ -36,3 +36,31 @@ When doing a new release for the Desktop Client like `2.x`, a new version branch
     the `2.x` branch gets protected and the `2.x-2` branch is no longer protected.
 18. Rename the `2.x-2` branch to `x_archived_2.x-2`
 
+**Text Suggestion for Step 2**
+
+The following text is a copy/paste suggestion for the PR in step 2, replace the branch numbers accordingly:
+```
+These are the changes necessary to finalize the creation of the 2.x branch.
+
+The 2.x branch is already pushed and prepared and is included in the branch protection rules.
+
+When 2.x (Desktop) is finally out, the 2.x-2 branch can be archived,
+see step 4 in https://github.com/owncloud/docs-client-desktop/blob/master/docs/new-version-branch.md
+
+Note, that the 2.x branch in this repo is already created, but the `latest` pointer on the web
+will be set to it automatically when the tag in Desktop is set. This means, that in the docs homepage,
+`latest` will point to 2.x-1 until the tag in Desktop is set accordingly. When merging this PR,
+2.x-2 will be dropped from the web but is available via pdf as usual.
+
+Note, this PR must be merged before the 2.x tag in Desktop is set to avoid a 404 for `latest`.
+
+Note that a PR in docs must be made to announce the 2.x branch. The docs PR must be merged AFTER this PR is merged to avoid a CI error in docs.
+
+Before merging this PR, we should take care that 2.x-2 has all changes necessary merged as post
+merging the 2.x-2 pdf is fixed.
+
+@michaelstingl @gabi18 fyi
+
+@mmattel @EParzefall @phil-davis
+post merging this, we need to backport all relevant changes to 2.x
+```


### PR DESCRIPTION
This PR updates the new branch documentation, fixes a typo and adds a copy/paste text for new branches (similar as in docs).

Backport to 2.10, 2.9 and 2.8 (if not already archived)