### PR TITLE
Document OWNCLOUD_OVERRIDE_SERVER_URL environment variable

### DIFF
--- a/modules/ROOT/pages/advanced_usage/environment_variables.adoc
+++ b/modules/ROOT/pages/advanced_usage/environment_variables.adoc
@@ -145,4 +145,8 @@ Set to -1 to never require full local discovery.
 | `QT_LOGGING_RULES`
 | unset
 | Set to "sync.httplogger=true" to enable verbose http logging. See also troubleshooting.adoc for more.
+
+| `OWNCLOUD_OVERRIDE_SERVER_URL`
+| unset
+| Set to override a previously configured/branded server URL
 |===


### PR DESCRIPTION
Implemented here: https://github.com/owncloud/client/pull/8772

@TheOneRing correct?

Backport to 2.9, not earlier!