### PR TITLE
Fix and update the building page

### DIFF
--- a/modules/ROOT/pages/appendices/building.adoc
+++ b/modules/ROOT/pages/appendices/building.adoc
@@ -1,4 +1,5 @@
 = Appendix Building the Client
+:toc: right
 :kde-craft-url: https://community.kde.org/Craft
 :kde-craft-build-from-source-url: https://community.kde.org/Guidelines_and_HOWTOs/Build_from_source/Windows
 :install-powershell-url: https://docs.microsoft.com/en-us/powershell/scripting/install/installing-windows-powershell?view=powershell-6
@@ -16,13 +17,12 @@
 :macports-url: http://www.macports.org
 :owncloud-obs: http://software.opensuse.org/download/package?project=isv:ownCloud:desktop&package=owncloud-client
 :opensuse-url: http://download.opensuse.org/repositories/isv:/ownCloud:/desktop/
+:description: This section explains how to build the ownCloud Client from source for all major platforms. You should read this section if you want to develop for the desktop client.
 :page-aliases: building.adoc
 
 == Introduction
 
-This section explains how to build the link:https://owncloud.org/download/#owncloud-desktop-client[ownCloud Client] from source for all major platforms.
-You should read this section if you want to develop for the desktop client.
-Build instructions are subject to change as development proceeds.
+{description} Build instructions are subject to change as development proceeds, the source can be found at link:https://owncloud.org/download/#owncloud-desktop-client[ownCloud Client].
 
 NOTE: Please check the version for which you want to build.
 
@@ -30,19 +30,15 @@ These instructions are updated to work with the latest version of the ownCloud C
 
 == Getting the Source Code
 
-The
-xref:generic-build-instructions[generic build instructions]
-pull the latest code directly from GitHub, and work on
-xref:linux[Linux], xref:macos[Mac OS X], and 
-xref:windows-development-build-with-kde-craft[Windows].
+The xref:generic-build-instructions[generic build instructions] pull the latest code directly from GitHub, and work on xref:linux[Linux], xref:macos[Mac OS X], and xref:windows-development-build-with-kde-craft[Windows].
 
 == Linux
 
-For the published desktop clients we link against QT5 dependencies from our own repositories so that we can have the same versions on all distributions. This chapter shows you how to build the client yourself with this setup. If you want to use the QT5 dependencies from your system, see the next chapter.
+=== Building With Provided QT5 Dependencies
 
-You may wish to use source packages for your Linux distribution, as these give you the exact sources from which the binary packages are built. These are hosted on the 
-{owncloud-obs}[ownCloud repository from OBS].
-Go to the {opensuse-url}[Index of repositories] to see all the Linux client repositories.
+For the published desktop clients, we link against QT5 dependencies from our own repositories so that we can have the same versions on all distributions. This chapter shows you how to build the client yourself with this setup. If you want to use the QT5 dependencies from your system, see the next chapter.
+
+You may wish to use source packages for your Linux distribution, as these give you the exact sources from which the binary packages are built. These are hosted on the {owncloud-obs}[ownCloud repository from OBS]. Go to the {opensuse-url}[Index of repositories] to see all the Linux client repositories.
 
 [NOTE]
 ====
@@ -59,22 +55,51 @@ echo 'deb-src http://download.opensuse.org/repositories/isv:/ownCloud:/desktop/D
 ----
 ====
 
-The above registers the source repository of the released client. There is also `.../desktop:/testing/...` and e.g. `.../desktop:/daily:/2.7/...` for beta versions or daily snapshots.
+The above registers the source repository of the released client.
 
+There is also:
+
+* `...isv:/ownCloud:/desktop:/testing/...`
+
+// needed dummy
+and e.g.
+
+* `...isv:/ownCloud:/desktop:/daily:/2.6/...`
+
+for beta versions or daily snapshots.
 
 Install the dependencies using the following commands for your specific Linux distribution. Make sure the repositories for source packages are enabled. These are:
 
 [cols="30%,70%",options="header"]
 |===
-| Distribution | Installation Instructions
-| Debian/Ubuntu | `apt update; apt build-dep owncloud-client`
-| openSUSE/SLES | `zypper ref; zypper si -d owncloud-client`
-| Fedora/CentOS/RHEL | `yum install yum-utils; yum-builddep owncloud-client`
+| Distribution
+| Installation Instructions
+
+| Debian / Ubuntu
+a|
+[source,bash]
+----
+apt update && apt build-dep owncloud-client
+----
+
+| openSUSE / SLES
+a|
+[source,bash]
+----
+zypper ref && zypper si -d owncloud-client
+----
+
+| Fedora / CentOS / RHEL
+a|
+[source,bash]
+----
+yum install yum-utils && yum-builddep owncloud-client
+----
 |===
 
 Follow the xref:generic-build-instructions[generic build instructions], starting with step 2.
 
-== Linux with System Dependencies
+=== Building With System QT5 Dependencies
 
 Build sources from a GitHub checkout with dependencies provided by your Linux distribution. While this allows more freedom for development, it does not exactly represent what we ship as packages. See above for how to recreate packages from source.
 
@@ -84,9 +109,12 @@ To get the source dependencies on Debian and Ubuntu, run the following command:
 
 [source,bash]
 ----
-sudo apt install qtdeclarative5-dev libinotifytools-dev \
-  qt5keychain-dev python3-sphinx \
-  libsqlite3-dev
+sudo apt install \
+    qtdeclarative5-dev \
+    libinotifytools-dev \
+    qt5keychain-dev \
+    python3-sphinx \
+    libsqlite3-dev
 ----
 ====
 
@@ -291,7 +319,7 @@ git clone git://github.com/owncloud/client.git
 cd client
 ----
 +
-Note master this default, but you can also check out a tag like v2.5.4
+Note that the checkout defaults to master, you can also check out a tag like v2.10.1
 +
 [source,bash]
 ----
@@ -317,18 +345,20 @@ cd client-build
 cmake -DCMAKE_PREFIX_PATH=/opt/ownCloud/qt-5.12.4 -DCMAKE_INSTALL_PREFIX=/Users/path/to/client/../install/ ..
 ----
 +
-For Linux builds (using QT5 libraries via build-dep) a typical setting is 
+For Linux builds (using QT5 libraries via build-dep) a typical setting is:
 +
 [source,console]
 ----
 -DCMAKE_PREFIX_PATH=/opt/ownCloud/qt-5.12.4/
 ----
 +
-However, the version number may vary. For Linux builds using system dependencies `-DCMAKE_PREFIX_PATH` is not needed. You must use absolute paths for the `include` and `library` directories.
+However, the version number may vary.
++
+For Linux builds using system dependencies `-DCMAKE_PREFIX_PATH` is not needed. You must use absolute paths for the `include` and `library` directories.
 +
 On Mac OS X, you need to specify `-DCMAKE_INSTALL_PREFIX=target`, where `target` is a private location, i.e. in parallel to your build dir by specifying `../install`.
 +
-qtkeychain must be compiled with the same prefix e.g., 
+`qtkeychain` must be compiled with the same prefix e.g., 
 +
 [source,console]
 ----
@@ -345,8 +375,10 @@ make
 +
 The ownCloud binary will appear in the `bin` directory.
 
+*Optional Steps*
+
 [start=5]
-. (Optional) Call `make install` to install the client to the `/usr/local/bin` directory (or as per CMAKE_INSTALL_PREFIX). +
+. Call `make install` to install the client to the `/usr/local/bin` directory (or as per CMAKE_INSTALL_PREFIX). +
 The following are known CMake parameters:
 
 * `QTKEYCHAIN_LIBRARY=/path/to/qtkeychain.dylib -DQTKEYCHAIN_INCLUDE_DIR=/path/to/qtkeychain/`
@@ -358,7 +390,7 @@ The following are known CMake parameters:
 * `CMAKE_PREFIX_PATH=/path/to/Qt5.12.4/5.12.4/yourarch/lib/cmake/`: Builds using that Qt version.
 * `CMAKE_INSTALL_PREFIX=path`: Set an install prefix. This is mandatory on Mac OS.
 +
-. *Optional:* Run a client that was installed in a custom CMAKE_INSTALL_PREFIX may not pick up the correct libraries automatically. You can use LD_LIBRARY_PATH to help find the libraries like this:
+. Run a client that was installed in a custom `CMAKE_INSTALL_PREFIX` may not pick up the correct libraries automatically. You can use `LD_LIBRARY_PATH` to help find the libraries like this:
 +
 [source,console]
 ----


### PR DESCRIPTION
This is the first part fixing #241 (Add cmake option for building the client to disable auto updater)

Before weare going to implement additional cmake options, we need to update the page as it needs a base review.

**IMPORTANT**
When looking into the given links adding the deb packages, you see that releases end with 2.6 (!!) and are 2 years old, see: `http://download.opensuse.org/repositories/isv:/ownCloud:/desktop/` 
Currently we are shipping 2.10 and are working on 2.11 ...

I need advise how to hande this **before we are going to merge this PR** because imho this is not a good sign showing customers heavy outdated release bases for building their client.

@dragotin @TheOneRing @michaelstingl 