### PR TITLE
Clarify changed bandwidth behaviour in 3.0+

### DIFF
--- a/modules/ROOT/pages/navigating.adoc
+++ b/modules/ROOT/pages/navigating.adoc
@@ -203,12 +203,17 @@ Proxy Settings::
 ** SOCKS5
 
 Download and Upload Bandwidth::
+
+The following options are available:
+
 * No limit
 * Limit automatically +
 When activated, the client limits the upload or download bandwidth to 25% of the currently available bandwidth for each operation. The available bandwidth is measured on the fly at the beginning of every operation for a very short period of time.
 * Limit to
 
 image::navigating/settings_network.png[Network Settings,width=60%,pdfwidth=60%]
+
+Changed settings will affect all new transfers (next upload chunk or next download), but not affect already running transfers.
 
 === Using the Ignored Files Editor
 

--- a/modules/ROOT/pages/navigating.adoc
+++ b/modules/ROOT/pages/navigating.adoc
@@ -215,7 +215,7 @@ image::navigating/settings_network.png[Network Settings,width=60%,pdfwidth=60%]
 
 [NOTE]
 ====
-Enabling this feature will affect all new transfers (next upload chunk or next download), but not affect already running transfers. Changing this setting or disabling this feature with take effect immediately.
+Enabling this feature will affect all new transfers (next upload chunk or next download), but not affect already running transfers (current upload chunk or current download). Changing this setting or disabling this feature with take effect immediately.
 ====
 
 === Using the Ignored Files Editor

--- a/modules/ROOT/pages/navigating.adoc
+++ b/modules/ROOT/pages/navigating.adoc
@@ -213,7 +213,10 @@ When activated, the client limits the upload or download bandwidth to 25% of the
 
 image::navigating/settings_network.png[Network Settings,width=60%,pdfwidth=60%]
 
-Changed settings will affect all new transfers (next upload chunk or next download), but not affect already running transfers.
+[NOTE]
+====
+Enabling this feature will affect all new transfers (next upload chunk or next download), but not affect already running transfers. Changing this setting or disabling this feature with take effect immediately.
+====
 
 === Using the Ignored Files Editor
 


### PR DESCRIPTION
Related client PR:
https://github.com/owncloud/client/pull/10112

@mmattel only merge to 3.0+  --> NO backport