### PR TITLE
Note about what is a hidden file (sync hidden file setting)

### DIFF
--- a/modules/ROOT/pages/navigating.adoc
+++ b/modules/ROOT/pages/navigating.adoc
@@ -179,6 +179,9 @@ The Settings Window has configuration options such as
 
 * Show sync folders in Explorer's Navigation Pane
 * Sync hidden files
++
+NOTE: Hidden files are files starting with a dot like `.filename.txt`, but not files which are hidden by setting a file attribute.
+
 * Show crash reporter and the
 * Buttons for btn:[Edit Ignored Files] (xref:using-the-ignored-files-editor[see below]) and btn:[Log settings]
 


### PR DESCRIPTION
Fixes: https://github.com/owncloud/docs-client-desktop/issues/272 (Document that hidden files are .files)

As the tite says. Important clarification for Windows users

Backport to 2.11 and 2.10

@tbsbdr fyi