### PR TITLE
Changes necessary for 3.0

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -6,7 +6,7 @@ def main(ctx):
     # Version shown as latest in generated documentations
     # It's fine that this is out of date in version branches, usually just needs
     # adjustment in master/deployment_branch when a new version is added to site.yml
-    latest_version = "2.11"
+    latest_version = "3.0"
     default_branch = "master"
 
     # Current version branch (used to determine when changes are supposed to be pushed)

--- a/site.yml
+++ b/site.yml
@@ -28,8 +28,8 @@ asciidoc:
     idseparator: '-'
     experimental: ''
 #   desktop
-    latest-desktop-version: '2.11'
-    previous-desktop-version: '2.10'
+    latest-desktop-version: '3.0'
+    previous-desktop-version: '2.11'
   extensions:
     - ./lib/extensions/tabs.js
     - ./lib/extensions/remote-include-processor.js


### PR DESCRIPTION
These are the changes necessary to finalize the creation of the 3.0 branch.

The 3.0 branch is already pushed and prepared and is included in the branch protection rules.

When 3.0 (Desktop) is finally out, the 2.10 branch can be archived,
see step 4 in https://github.com/owncloud/docs-client-desktop/blob/master/docs/new-version-branch.md

Note, that the 3.0 branch in this repo is already created, but the `latest` pointer on the web
will be set to it automatically when the tag in Desktop is set. This means, that in the docs homepage,
`latest` will point to 2.11 until the tag in Desktop is set accordingly. When merging this PR,
2.10 will be dropped from the web but is available via pdf as usual.

Note, this PR must be merged before the 3.0 tag in Desktop is set to avoid a 404 for `latest`.

Note that a PR in docs must be made to announce the 3.0 branch. The docs PR must be merged AFTER this PR is merged to avoid a CI error in docs.

Before merging this PR, we should take care that 2.10 has all changes necessary merged as post
merging the 2.10 pdf is fixed.

@michaelstingl @gabi18 @TheOneRing fyi 

@mmattel @EParzefall @phil-davis
post merging this, we need to backport all relevant changes to 3.0