### PR TITLE
Adding info about client restart after ignored list changes

### DIFF
--- a/modules/ROOT/pages/navigating.adoc
+++ b/modules/ROOT/pages/navigating.adoc
@@ -237,6 +237,8 @@ Patterns that end with a slash character (`/`) are applied to only directory com
 
 NOTE: Custom entries are currently not validated for syntactical correctness by the editor, so you will not see any warnings for bad syntax. If your synchronization does not work as you expected, check your syntax.
 
+NOTE: A restart of the client is needed in order for the changes to the editor to the take effect. 
+
 Each pattern string in the list is preceded by a checkbox. When the checkbox contains a check mark, in addition to ignoring the file or directory component matched by the pattern, any matched files are also deemed "fleeting metadata" and removed by the client.
 
 In addition to excluding files and directories that use patterns defined in this list:

--- a/modules/ROOT/pages/navigating.adoc
+++ b/modules/ROOT/pages/navigating.adoc
@@ -237,7 +237,7 @@ Patterns that end with a slash character (`/`) are applied to only directory com
 
 NOTE: Custom entries are currently not validated for syntactical correctness by the editor, so you will not see any warnings for bad syntax. If your synchronization does not work as you expected, check your syntax.
 
-NOTE: A restart of the client is needed in order for the changes to the editor to the take effect. 
+NOTE: A restart of the client is needed in order for the changes to the editor to take effect. 
 
 Each pattern string in the list is preceded by a checkbox. When the checkbox contains a check mark, in addition to ignoring the file or directory component matched by the pattern, any matched files are also deemed "fleeting metadata" and removed by the client.
 

--- a/modules/ROOT/pages/navigating.adoc
+++ b/modules/ROOT/pages/navigating.adoc
@@ -237,7 +237,7 @@ Patterns that end with a slash character (`/`) are applied to only directory com
 
 NOTE: Custom entries are currently not validated for syntactical correctness by the editor, so you will not see any warnings for bad syntax. If your synchronization does not work as you expected, check your syntax.
 
-NOTE: A restart of the client is needed in order for the changes to the editor to take effect. 
+NOTE: A restart of the client is needed in order for the changes to take effect. 
 
 Each pattern string in the list is preceded by a checkbox. When the checkbox contains a check mark, in addition to ignoring the file or directory component matched by the pattern, any matched files are also deemed "fleeting metadata" and removed by the client.
 


### PR DESCRIPTION
Sync client restart is needed for changes to the ignored files list to take place. This is currently not documented and can be confusing for the users as this is not consistent to what described in the client itself.

<img width="486" alt="image" src="https://user-images.githubusercontent.com/12248713/206725407-eee43c29-4df2-4648-aff6-0d8a1ed90ddd.png">

@michaelstingl maybe we should also adjust the text in the client.

Backport to 3.0 and 2.11