### PR TITLE
Fix a broken internal link

### DIFF
--- a/modules/ROOT/pages/appendices/building.adoc
+++ b/modules/ROOT/pages/appendices/building.adoc
@@ -192,7 +192,7 @@ After you install KDE Craft, there are two steps left before the ownCloud Deskto
 These are:
 
 . xref:launch-the-kde-craft-environment[Launch the KDE Craft Environment]
-. xref:build-the-client[Build the Desktop App]
+. xref:build-the-desktop-app[Build the Desktop App]
 
 ==== Launch the KDE Craft Environment
 


### PR DESCRIPTION
As the title says, found via htmltest.

Backport to 3.0 and 2.11