### PR TITLE
Add fixes to the appimage description

### DIFF
--- a/modules/ROOT/pages/installing.adoc
+++ b/modules/ROOT/pages/installing.adoc
@@ -117,6 +117,12 @@ issue with `libfuse` on Ubuntu >=22.04 or Debian 11 {libfuse2-url}[Setting up FU
 
 * There is no automatic updating. Any update is like installing the AppImage.
 
+Known limitations for the 3.0.x AppImage::
+The known limitations are the same as for 2.11.x except:
+
+* AppImages are now starting automatically.
+* AppImages now have automatic updating.
+
 Installing _libfuse2_ if required::
 --
 * Check if `libfuse2` is already installed:


### PR DESCRIPTION
Fixes: #306 Update AppImage limitations list

New limitations for the AppImage 3.0 version

Backport to 3.0 only