### PR TITLE
[Windows] Clarify requirement for native WinVFS

### DIFF
--- a/modules/ROOT/pages/faq.adoc
+++ b/modules/ROOT/pages/faq.adoc
@@ -3,11 +3,15 @@
 :wordpress1-url: http://petersteier.wordpress.com/2011/10/22/windows-indexer-changes-modification-dates-of-eml-files/
 :user_manual_quota: https://doc.owncloud.com/server/next/user_manual/files/webgui/quota.html
 
-:description: Here you can find some of the most frequently asked questions about the ownCloud Desktop app.
+:description: Here you can find some of the most frequently asked questions about the ownCloud Desktop App.
 
 == Introduction
 
 {description}
+
+== VFS for Windows Server
+
+Without claim of completeness, actuality or support, Windows Server releases that are based on builds starting with 1709 should come with the native system API that is required to use VFS. Windows Servers 2016 and lower do not have native VFS included and will not be able to use VFS therefore.
 
 == Usage
 

--- a/modules/ROOT/pages/faq.adoc
+++ b/modules/ROOT/pages/faq.adoc
@@ -3,7 +3,7 @@
 :wordpress1-url: http://petersteier.wordpress.com/2011/10/22/windows-indexer-changes-modification-dates-of-eml-files/
 :user_manual_quota: https://doc.owncloud.com/server/next/user_manual/files/webgui/quota.html
 
-:description: Here you can find some of the most frequently asked questions about the ownCloud Desktop App.
+:description: Here you can find some of the most frequently asked questions about the ownCloud Desktop app.
 
 == Introduction
 

--- a/modules/ROOT/pages/faq.adoc
+++ b/modules/ROOT/pages/faq.adoc
@@ -29,6 +29,10 @@ The Desktop App has been intentionally limited to sync no deeper than 100 sub-di
 
 When other users share data with you, it's downloaded to the sync folder and counted as space used by the Desktop App, although it doesn't affect your quota for storage usage. There are more factors taken into account when calculating the quota status. For more information, see the {user_manual_quota}[Storage Quotas in the User Manual].
 
+=== The Desktop Client Shows Different File Sizes Than my Mobile App
+
+The file size values differ depending on the client you are using. Some operating systems like iOS and macOS use the decimal system (power of 10) where 1kB or one kilobyte consists of 1000 bytes, while Linux, Android and Windows use the binary system (power of 2) where 1KB consists of 1024 bytes and is called a kibibyte. So no reason to worry if you see different file sizes in your desktop client than on your mobile devices or the web interface.
+
 == Major Configuration Changes
 
 === I Want to Move My Local Sync Folder

--- a/modules/ROOT/pages/installing.adoc
+++ b/modules/ROOT/pages/installing.adoc
@@ -31,7 +31,8 @@ Depending on the operating system used, some minimum system requirements need to
 Windows::
 * Windows 7+
 ** x86 with 32-bit or x86-64 with 64-bit
-** Native WinVFS available for Windows versions 1709 or later
+** Native WinVFS available for Windows versions 1709 or later. +
+For Windows Server you find the version in `winver` in the second row. The known versions can be identified via the following referenced list: https://en.wikipedia.org/wiki/Windows_Server#Semi-annual_releases_(discontinued)[Semi-annual releases (discontinued)].
 
 macOS::
 * macOS 10.12+

--- a/modules/ROOT/pages/installing.adoc
+++ b/modules/ROOT/pages/installing.adoc
@@ -31,7 +31,7 @@ Depending on the operating system used, some minimum system requirements need to
 Windows::
 * Windows 7+
 ** x86 with 32-bit or x86-64 with 64-bit
-** Native WinVFS available for Windows 10 version 1709 or later
+** Native WinVFS available for Windows versions 1709 or later
 
 macOS::
 * macOS 10.12+

--- a/modules/ROOT/pages/installing.adoc
+++ b/modules/ROOT/pages/installing.adoc
@@ -29,10 +29,9 @@ You can download the latest version of the ownCloud Desktop App from the {deskto
 Depending on the operating system used, some minimum system requirements need to be met. ownCloud provides Linux packages for a variety of Linux distributions, see the list of supported distros below.
 
 Windows::
-* Windows 7+
+* Windows 7 or later
 ** x86 with 32-bit or x86-64 with 64-bit
-** Native WinVFS available for Windows versions 1709 or later. +
-For Windows Server you find the version in `winver` in the second row. The known versions can be identified via the following referenced list: https://en.wikipedia.org/wiki/Windows_Server#Semi-annual_releases_(discontinued)[Semi-annual releases (discontinued)].
+** For xref:vfs.adoc[VFS support], Windows 10 versions 1709 or later.
 
 macOS::
 * macOS 10.12+

--- a/modules/ROOT/pages/vfs.adoc
+++ b/modules/ROOT/pages/vfs.adoc
@@ -4,9 +4,11 @@
 :placeholder-files-url: https://docs.microsoft.com/en-us/windows/win32/cfapi/build-a-cloud-file-sync-engine
 :onedrive-restrictions-url: https://support.microsoft.com/en-us/office/restrictions-and-limitations-in-onedrive-and-sharepoint-64883a5d-228e-48f5-b3d2-eb39e07630fa?ui=en-US&rs=en-US&ad=US#filenamepathlengths
 
+:description: ownCloud offers the possibility for users to enable a virtual file system (VFS) when synchronizing data.
+
 == Introduction
 
-ownCloud offers the possibility for users to enable a virtual file system (VFS) when synchronizing data. This has the big advantage that all files and folders are visible to the Desktop App, but the files are not downloaded until the user requests to do so. Here are some of the key benefits:
+{description} This has the big advantage that all files and folders are visible to the Desktop App, but the files are not downloaded until the user requests to do so. Here are some of the key benefits:
 
 * Full access to files and folders without having to download them all first
 * Selectively sync folders and files based on user requirements

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "antora": "antora --stacktrace generate --cache-dir cache --redirect-facility static --generator ./generator/generate-site.js --clean --fetch --attribute format=html site.yml",
     "antora-local": "antora --stacktrace generate --cache-dir cache --redirect-facility static --generator ./generator/generate-site.js --clean --fetch --attribute format=html --url http://localhost:8080 site.yml",
     "antora-staging": "antora --stacktrace generate --cache-dir cache --redirect-facility static --generator ./generator/generate-site.js --clean --fetch --attribute format=html --url https://doc.staging.owncloud.com site.yml",
+    "antora-bundle": "antora --stacktrace generate --cache-dir cache --redirect-facility static --generator ./generator/generate-site.js --clean --fetch --attribute format=html --ui-bundle-url ../docs-ui/build/ui-bundle.zip --url https://doc.staging.owncloud.com site.yml",
     "validate": "antora --stacktrace generate --cache-dir cache --redirect-facility disabled --generator ./generator/xref-validator.js --clean --fetch --attribute format=html site.yml",
     "linkcheck": "broken-link-checker --filter-level 3 --recursive --verbose"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -926,13 +926,13 @@ function-bind@^1.1.1:
   integrity sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==
 
 get-intrinsic@^1.0.2:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.1.1.tgz#15f59f376f855c446963948f0d24cd3637b4abc6"
-  integrity sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.1.3.tgz#063c84329ad93e83893c7f4f243ef63ffa351385"
+  integrity sha512-QJVz1Tj7MS099PevUG5jvnt9tSkXN8K14dxQlikJuPt4uD9hHAHjLyLBiLR5zELelBdD9QNRAXZzsJx0WaDL9A==
   dependencies:
     function-bind "^1.1.1"
     has "^1.0.3"
-    has-symbols "^1.0.1"
+    has-symbols "^1.0.3"
 
 get-stream@^4.1.0:
   version "4.1.0"
@@ -1094,6 +1094,11 @@ has-symbols@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.2.tgz#165d3070c00309752a1236a479331e3ac56f1423"
   integrity sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==
+
+has-symbols@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.3.tgz#bb7b2c4349251dce87b125f7bdf874aa7c8b39f8"
+  integrity sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==
 
 has@^1.0.3:
   version "1.0.3"
@@ -1603,9 +1608,9 @@ object-assign@^4.1.1:
   integrity sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=
 
 object-inspect@^1.9.0:
-  version "1.10.3"
-  resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.10.3.tgz#c2aa7d2d09f50c99375704f7a0adf24c5782d369"
-  integrity sha512-e5mCJlSH7poANfC8z8S9s9S2IN5/4Zb3aZ33f5s8YqoazCFzNLloLU8r5VCG+G7WoqLvAAZoVMcy3tp/3X0Plw==
+  version "1.12.2"
+  resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.12.2.tgz#c0641f26394532f28ab8d796ab954e43c009a8ea"
+  integrity sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ==
 
 object-keys@^1.0.12, object-keys@^1.1.1:
   version "1.1.1"
@@ -1806,9 +1811,9 @@ punycode@^2.1.1:
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
 
 qs@^6.4.0:
-  version "6.10.1"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.10.1.tgz#4931482fa8d647a5aab799c5271d2133b981fb6a"
-  integrity sha512-M528Hph6wsSVOBiYUnGf+K/7w0hNshs/duGsNXPUCLH5XAqjEtiPGwNONLV0tBH8NoGb0mvD5JubnUTrujKDTg==
+  version "6.11.0"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.11.0.tgz#fd0d963446f7a65e1367e01abd85429453f0c37a"
+  integrity sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==
   dependencies:
     side-channel "^1.0.4"
 


### PR DESCRIPTION
According to my knowledge, native WinVFS works on all Win versions > 1709 (Win 10, 11, Win server 2019 + 2022)

@TheOneRing works for you?

Backport to master and 2.9