### PR TITLE
Fixe the command line page

### DIFF
--- a/modules/ROOT/pages/advanced_usage/command_line_client.adoc
+++ b/modules/ROOT/pages/advanced_usage/command_line_client.adoc
@@ -77,7 +77,9 @@ Other command line switches supported by `owncloudcmd` include the following:
 | Displays help including Qt specific options.
 
 | `-v, --version`
-| Displays version information.|===
+| Displays version information.
+|===
+
 == Credential Handling
 
 `owncloudcmd` requires the user to specify the username and password using the standard URL pattern, for example:

--- a/modules/ROOT/partials/nav.adoc
+++ b/modules/ROOT/partials/nav.adoc
@@ -11,7 +11,6 @@
 ** xref:advanced_usage/command_line_client.adoc[The Command Line Client]
 ** xref:advanced_usage/configuration_file.adoc[Configuration File]
 ** xref:advanced_usage/environment_variables.adoc[Environment Variables]
-** xref:advanced_usage/command_line_client.adoc[Command-Line Options]
 ** xref:advanced_usage/low_disk_space.adoc[Low Disk Space]
 * xref:appendices/index.adoc[Appendices]
 ** xref:appendices/building.adoc[Building the Desktop App]


### PR DESCRIPTION
References: #315 (Fix owncloudcmd)

* accidentially the table was not closed properly
* though removing a dupe page and setting an alias, the page was still available in the navigation

Backport to 3.0