### PR TITLE
Followup fix for guitest

### DIFF
--- a/modules/ROOT/pages/appendices/guitest.adoc
+++ b/modules/ROOT/pages/appendices/guitest.adoc
@@ -124,7 +124,7 @@ sudo docker pull owncloudci/squish
 * xref:run-tests-using-squish[Run Tests Using Squish]
 * xref:run-tests-using-docker[Run Tests Using Docker]
 
-NOTE: Before running middleware, install {yarn-install-url}[yarn] respectively {pnpm-install-url}[pnpm] and clone middleware from {owncloud-test-middleware-url}[here].
+NOTE: Before running middleware, install {yarn-install-url}[yarn] and clone middleware from {owncloud-test-middleware-url}[here].
 
 === Run Tests Using Squish
 

--- a/modules/ROOT/pages/appendices/guitest.adoc
+++ b/modules/ROOT/pages/appendices/guitest.adoc
@@ -99,9 +99,9 @@ NOTE: If you are testing against the oCIS server, set *OCIS=true* in the *config
 
 NOTE: If there are problems with starting Squish, please check the log file `~/.squish/squishlibraryx.log.x`. Also make sure that the `~/squish-for-qt-6.x.x/etc/paths.ini` is user-readable.
 
-===== Extra Steps for oCIS
+===== Extra Steps for Infinite Scale
 
-While running the tests against oCIS, playwright is used to automate the login process in the browser. Following extra steps need to be taken:
+While running the tests against Infinite Scale, playwright is used to automate the login process in the browser. The following extra steps need to be taken:
 
 . Install {node-install-url}[node] and {pnpm-install-url}[pnpm]
 . Go to `test/gui/webUI` and run `pnpm install`

--- a/modules/ROOT/pages/appendices/guitest.adoc
+++ b/modules/ROOT/pages/appendices/guitest.adoc
@@ -14,6 +14,7 @@
 :client-repo-url: https://github.com/owncloud/client/
 :node-install-url: https://nodejs.org/en/download/package-manager
 :pnpm-install-url: https://pnpm.io/installation
+:yarn-install-url: https://classic.yarnpkg.com/en/docs/install/#debian-stable
 
 == Introduction
 
@@ -99,7 +100,8 @@ NOTE: If you are testing against the oCIS server, set *OCIS=true* in the *config
 NOTE: If there are problems with starting Squish, please check the log file `~/.squish/squishlibraryx.log.x`. Also make sure that the `~/squish-for-qt-6.x.x/etc/paths.ini` is user-readable.
 
 ===== Extra Steps for oCIS
-While running the tests against oCIS, playwright is used to automate the login process in the browser. So we need to do the following extra steps:
+
+While running the tests against oCIS, playwright is used to automate the login process in the browser. Following extra steps need to be taken:
 
 . Install {node-install-url}[node] and {pnpm-install-url}[pnpm]
 . Go to `test/gui/webUI` and run `pnpm install`
@@ -122,7 +124,7 @@ sudo docker pull owncloudci/squish
 * xref:run-tests-using-squish[Run Tests Using Squish]
 * xref:run-tests-using-docker[Run Tests Using Docker]
 
-NOTE: Before running middleware, install yarn following the instructions from {yarn-install-url}[here] and clone middleware from {owncloud-test-middleware-url}[here].
+NOTE: Before running middleware, install {yarn-install-url}[yarn] respectively {pnpm-install-url}[pnpm] and clone middleware from {owncloud-test-middleware-url}[here].
 
 === Run Tests Using Squish
 


### PR DESCRIPTION
Referencing #329 (update testing doc for oCIS)

The referenced PR removed an attribute making the build fail because no checking was made before merging 👎 

This PR fixes the missing attribute but needs checking if the changes are ok in the context.

Backport to 3.0