### PR TITLE
Fix image width

### DIFF
--- a/modules/ROOT/pages/appendices/troubleshooting.adoc
+++ b/modules/ROOT/pages/appendices/troubleshooting.adoc
@@ -70,7 +70,7 @@ Desktop App log files contain file and folder names, metadata, server URLs and o
 +
 The Log Output window opens.
 +
-image:appendices/troubleshooting/log_output_window.png[image,width=60%,pdfwidth=60%]
+image::appendices/troubleshooting/log_output_window.png[image,width=600,pdfwidth=60%]
 +
 .  Enable the btn:[Enable logging to temporary folder] checkbox.
 .  Later, to find the log files, click the btn:[Open folder] button.

--- a/modules/ROOT/pages/faq.adoc
+++ b/modules/ROOT/pages/faq.adoc
@@ -51,11 +51,11 @@ according your needs.
 +
 To do so, in the Desktop App UI, which you can see below, click the drop-down menu menu:Account[Remove].
 +
-image:faq/ownCloud-remove_existing_connection.png[image, width=80%,pdfwidth=60%]
+image::faq/ownCloud-remove_existing_connection.png[image, width=500,pdfwidth=60%]
 +
 This will display a "*Confirm Account Removal*" dialog window. If you're sure, click btn:[Remove connection].
 +
-image:faq/ownCloud-remove_existing_connection_confirmation_dialog.png[image, width=60%,pdfwidth=60%]
+image::faq/ownCloud-remove_existing_connection_confirmation_dialog.png[image]
 
 ..  Add a new connection which syncs to the desired directory.
 +
@@ -70,7 +70,7 @@ Be careful before choosing the "Start a clean sync" option. The old sync folder 
 Instead, first move or copy the old local sync folder, containing a copy of the existing files, to the new location. Then, when creating the new connection choose "_keep existing data_" instead. The ownCloud Desktop App will check the files in the newly-added sync folder and find that they match what is on the server and not need to download anything.
 ====
 +
-image:faq/ownCloud-replacement_connection_wizard.png[image, width=80%,pdfwidth=60%]
+image::faq/ownCloud-replacement_connection_wizard.png[image, width=500,pdfwidth=60%]
 +
 Make your choice and click btn:[Connect...] This will then lead you through the Connection Wizard, just like when you set up the previous sync connection, but giving you the opportunity to choose a new sync directory.
 
@@ -94,7 +94,7 @@ Keeping software up to date is crucial for file integrity and security – if so
 
 The ownCloud Desktop App talks to a server, e.g. the ownCloud server, so you do not only have to upgrade your Desktop App when there is a new version for it, also the server has to be kept up-to-date by your sysadmin. Starting with version 2.5.0, the Desktop App will show a warning message if you connect to an outdated or unsupported server:
 
-image:faq/oc-unsupported-version-warning-message.png[image, width=80%,pdfwidth=60%]
+image::faq/oc-unsupported-version-warning-message.png[image, width=600,pdfwidth=60%]
 
 Only ownCloud 10.0.0 or Higher Is Supported::
 If you encounter such a message, you should ask your administrator to upgrade ownCloud to a secure version because earlier versions are not maintained anymore. An important feature of the ownCloud Desktop App is checksumming – each time you download or upload a file, the Desktop App and the server both check if the file was corrupted during the sync. This way you can be sure that you don’t lose any files.
@@ -106,7 +106,7 @@ That’s why you see this warning message, so you can evaluate your data securit
 
 === Multiple Accounts Sharing the Folder
 
-image:faq/01_multiple-accounts-sharing-folder.png[image, width=80%,pdfwidth=60%]
+image::faq/01_multiple-accounts-sharing-folder.png[image, width=550,pdfwidth=60%]
 
 Desktop App discovered multiple sync journals (SQLite database files) in the folder. That indicates that multiple Desktop Apps are using the same folder as a sync root. Under certain conditions it could also mean that there is an old `._sync_#HASH.db` or `.sync_#HASH.db` in the folder.
 
@@ -116,8 +116,12 @@ Such a file will have an old change date and usually can be removed.
 
 === Folder Is Used in a Folder Sync Connection
 
-image:faq/02_folder-used-in-sync-connection1.png[image, width=80%,pdfwidth=60%]
-image:faq/03_folder-used-in-sync-connection2.png[image, width=80%,pdfwidth=60%]
+image::faq/02_folder-used-in-sync-connection1.png[image, width=550,pdfwidth=60%]
+
+{empty}
+{empty}
+
+image::faq/03_folder-used-in-sync-connection2.png[image, width=550,pdfwidth=60%]
 
 Similar to the above case, the Desktop App discovered one or more `.sync_journal.db` files in the directory. That means the folder is either already used by a different Desktop App for syncing or we again have an old SQLite database file in that folder. This can also happen if a user tries to import an old folder.
 
@@ -127,7 +131,7 @@ Such a file will have an old change date and usually can be removed.
 
 === Parent Folder Managed by Another Desktop App
 
-image:faq/04_folder-used-by-different-client.png[image, width=80%,pdfwidth=60%]
+image::faq/04_folder-used-by-different-client.png[image, width=550,pdfwidth=60%]
 
 This error can only happen with native Windows VFS. The Desktop App discovered that the folder is part of a subtree that is managed by another Desktop App, for example testpilotcloud. The difference to the next error is that we can't be sure it's a different Desktop App or an orphaned sync root.
 
@@ -139,7 +143,7 @@ Pick another sync folder.
 
 === Folder Used by Different Desktop App
 
-image:faq/05_folder-managed-by-another-sync-client.png[image, width=80%,pdfwidth=60%]
+image::faq/05_folder-managed-by-another-sync-client.png[image, width=550,pdfwidth=60%]
 
 This error can only happen with native Windows VFS. Desktop App discovered that the folder is part of a subtree that is managed by another Desktop App, for example OneDrive.
 

--- a/modules/ROOT/pages/installing.adoc
+++ b/modules/ROOT/pages/installing.adoc
@@ -91,7 +91,7 @@ sudo apt install gnome-shell-extension-appindicator
 
 When the extension is installed, you need to restart the GNOME shell. To do so, hit btn:[Alt+F2] on the keyboard, type btn:[r] and  btn:[Enter]. Now you will see the new extensions added to the extensions list. To enable an extension, switch the button on the right to the btn:[On] position. For the particular system tray icon extension, the name for all distributions is **Ubuntu AppIndicators** because the notification system AppIndicators has been developed by Ubuntu. Once enabled, the system tray is shown again within the desktop environment.
 
-image::installing/gnome-shell-extension-appindicator-selector.png[width=350%,pdfwidth=60%]
+image::installing/gnome-shell-extension-appindicator-selector.png[width=600,pdfwidth=60%]
 --
 
 ==== Native installation
@@ -155,21 +155,21 @@ See the {install-appimagelauncher-url}[Install AppImageLauncher] wiki for detail
 How to launch an AppImage::
 When you open an AppImage file via your file browser that you have not opened before then double click on it:
 +
-image:installing/appimagelauncher_open_question.png[AppImage First Time Usage,width=350]
+image::installing/appimagelauncher_open_question.png[AppImage First Time Usage, width=500]
 --
 +
 --
 First time usage::
 After opening an AppImage, if AppImageLauncher has been started for the first time, it will ask you to define some basic settings:
 +
-image:installing/appimagelauncher_first_run.png[AppImage First Time Usage,width=350]
+image::installing/appimagelauncher_first_run.png[AppImage First Time Usage,width=500]
 --
 +
 --
 AppImage Integration Question::
 Post first time configuration or when you open the AppImage file via your file browser, for example by double clicking on it:
 +
-image:installing/appimagelauncher_integrate_question.png[AppImage Integration Question,width=350]
+image::installing/appimagelauncher_integrate_question.png[AppImage Integration Question,width=500]
 --
 
 Install and run the Desktop App AppImage::
@@ -245,7 +245,7 @@ msiexec /passive /i ownCloud-x.y.z.msi REMOVE=DesktopShortcut
 See the following table for a list of available features:
 
 [width="100%",cols="20%,20%,27%,33%",options="header",]
-|=======================================================================
+|===
 | Feature 
 | Enabled by default 
 | Description 
@@ -271,7 +271,7 @@ required
 | Yes 
 | Adds Explorer integration 
 | `NO_SHELL_EXTENSIONS`
-|=======================================================================
+|===
 
 ==== Installation
 
@@ -392,15 +392,15 @@ See the: https://www.advancedinstaller.com/user-guide/qa-log.html[How do I creat
 
 The installation wizard takes you step-by-step through configuration options and account setup. First you need to enter the URL of your ownCloud server.
 
-image:installing/client-1.png[form for entering ownCloud server URL, width=60%,pdfwidth=60%]
+image::installing/client-1.png[form for entering ownCloud server URL, width=500,pdfwidth=60%]
 
 Enter your ownCloud login on the next screen.
 
-image:installing/client-2.png[form for entering your ownCloud login, width=60%,pdfwidth=60%]
+image::installing/client-2.png[form for entering your ownCloud login, width=500,pdfwidth=60%]
 
 On the _"Local Folder Option"_ screen you may sync all of your files on the ownCloud server, or select individual folders. The default local sync folder is `ownCloud`, in your home directory. You may change this as well.
 
-image:installing/client-3.png[Select which remote folders to sync, and which local folder to store them in, width=60%,pdfwidth=60%]
+image::installing/client-3.png[Select which remote folders to sync, and which local folder to store them in, width=500,pdfwidth=60%]
 
 When you have completed selecting your sync folders, click the _"Connect"_ button at the bottom right. The Desktop App will attempt to connect to your ownCloud server, and when it is successful you'll see two buttons:
 

--- a/modules/ROOT/pages/navigating.adoc
+++ b/modules/ROOT/pages/navigating.adoc
@@ -11,27 +11,27 @@
 
 == Used App Icons
 
-image:navigating/icon.png[image]
+image:navigating/icon.png[image-syncok]
 
 The status indicator uses icons to indicate the current status of your synchronization. The green circle with the white checkmark tells you that your synchronization is current and you are connected to your ownCloud server.
 
-image:navigating/icon-syncing.png[image]
+image:navigating/icon-syncing.png[image-syncing]
 
 The blue icon with the white semi-circles means synchronization is in progress.
 
-image:navigating/icon-paused.png[image]
+image:navigating/icon-paused.png[image-paused]
 
 The yellow icon with the parallel lines tells you your synchronization has been paused. (Most likely by you.)
 
-image:navigating/icon-offline.png[image]
+image:navigating/icon-offline.png[image-offline]
 
 The gray icon with three white dots means your Desktop App has lost its connection with your ownCloud server.
 
-image:navigating/icon-information.png[image]
+image:navigating/icon-information.png[image-information]
 
 When you see a white circle with the letter "i" that is the informational icon, so you should click it to see what it has to tell you.
 
-image:navigating/icon-error.png[image]
+image:navigating/icon-error.png[image-error]
 
 The red circle with the white "x" indicates a configuration error, such as an incorrect login or server URL.
 
@@ -39,7 +39,7 @@ The red circle with the white "x" indicates a configuration error, such as an in
 
 A right-click on the systray icon opens a menu for quick access to multiple operations.
 
-image::navigating/menu.png[image, width=60%,pdfwidth=60%]
+image::navigating/menu.png[systray, width=400,pdfwidth=60%]
 
 This menu provides the following options:
 
@@ -54,7 +54,7 @@ This menu provides the following options:
 
 A left-click on your systray icon opens the Desktop App to the account settings window.
 
-image::navigating/client6.png[image, width=60%,pdfwidth=60%]
+image::navigating/client6.png[image, width=600,pdfwidth=60%]
 
 === Configuring ownCloud Account Settings
 
@@ -89,7 +89,7 @@ Stop all sync activity
 Enable virtual file support::
 Enable the virtual file support for an account
 
-image::navigating/client-7.png[The Overflow Menu, width=60%,pdfwidth=60%]
+image::navigating/client-7.png[The Overflow Menu, width=250,pdfwidth=60%]
 
 NOTE: ownCloud does not preserve the mtime (modification time) of directories, though it does update the mtimes on files. See https://github.com/owncloud/core/issues/7009:[Wrong folder date when syncing] for discussion of this.
 
@@ -124,15 +124,15 @@ If a directory includes ignored files that are marked with warning icons that do
 
 The ownCloud Desktop App integrates with your file manager: Finder on Mac OS X, Explorer on Windows, and Nautilus on Linux. (Linux users must install the `owncloud-client-nautilus` plugin.) You can create share links, and share with internal ownCloud users the same way as in your ownCloud Web interface.
 
-image::navigating/mac-share.png[image, width=60%,pdfwidth=60%]
+image::navigating/mac-share.png[image, width=500,pdfwidth=60%]
 
 Right-click your systray icon, hover over the account you want to use, and left-click  menu:Open folder["folder name"] to quickly enter your local ownCloud folder. Right-click the file or folder you want to share to expose the share dialog, and click menu:Share with ownCloud[].
 
-image::navigating/share-1.png[image, width=70%,pdfwidth=70%]
+image::navigating/share-1.png[sharing_1, width=300,pdfwidth=70%]
 
 The share dialog has all the same options as your ownCloud Web interface.
 
-image::navigating/share-2.png[image, width=60%,pdfwidth=60%]
+image::navigating/share-2.png[sharing_2, width=300,pdfwidth=60%]
 
 Use *Share with ownCloud* to see who you have shared with, and to modify their permissions, or to delete the share.
 
@@ -149,7 +149,7 @@ Displays local activities such as which local folders your files went into.
 Not Synced::
 Shows errors such as files not synced because of being excluded or any other failing status.
 
-image::navigating/client-8.png[image, width=60%,pdfwidth=60%]
+image::navigating/client-8.png[not_synced, width=600,pdfwidth=60%]
 
 In Windows, double-clicking an activity entry pointing to an existing file in tabs *Server Activities* or *Sync Protocol*, will open the folder containing the file and highlight it.
 
@@ -163,7 +163,7 @@ The desktop client will display notifications from your ownCloud server that req
 
 For example, when a user on a remote ownCloud creates a new Federated share for you, you can accept it from your desktop client. This also displays notifications sent to users by the ownCloud admin via the Announcements app.
 
-image::navigating/client12.png[image,width=60%,pdfwidth=60%]
+image::navigating/client12.png[server_notifications,width=600,pdfwidth=60%]
 
 == Settings Window
 
@@ -190,7 +190,7 @@ NOTE: Hidden files are files starting with a dot like `.filename.txt`, but not f
 * Ask confirmation before downloading folders larger than [folder size]
 * Ask for confirmation before synchronizing external storages
 
-image::navigating/client-9.png[image, width=60%,pdfwidth=60%]
+image::navigating/client-9.png[advanced, width=600,pdfwidth=60%]
 
 TIP: While you can select whether to show or hide the crash reporter, from the Settings Window, you can also configure whether to show or hide it from the xref:advanced_usage/configuration_file.adoc#section-general[general section of the configuration file] as well. Doing so can help with debugging on-startup-crashes.
 
@@ -214,7 +214,7 @@ The following options are available:
 When activated, the client limits the upload or download bandwidth to 25% of the currently available bandwidth for each operation. The available bandwidth is measured on the fly at the beginning of every operation for a very short period of time.
 * Limit to
 
-image::navigating/settings_network.png[Network Settings,width=60%,pdfwidth=60%]
+image::navigating/settings_network.png[Network Settings,width=600,pdfwidth=60%]
 
 [NOTE]
 ====
@@ -225,7 +225,7 @@ Enabling this feature will affect all new transfers (next upload chunk or next d
 
 You might have some local files or directories that you do not want to backup and store on the server. To identify and exclude these files or directories, you can use the menu:Settings[Advanced > Ignored Files Editor]
 
-image::navigating/ignored_files_editor.png[Ingnored Files Editor,width=60%,pdfwidth=60%]
+image::navigating/ignored_files_editor.png[Ingnored Files Editor,width=350,pdfwidth=60%]
 
 For your convenience, the editor is pre-populated with a default list of typical ignore patterns. These patterns are contained in a system file. (typically `sync-exclude.lst`) located in the ownCloud Client application directory. You cannot modify these pre-populated patterns directly from the editor. However, if necessary, you can hover over any pattern in the list to show the path and filename associated with that pattern, locate the file, and edit the `sync-exclude.lst` file.
 

--- a/modules/ROOT/pages/vfs.adoc
+++ b/modules/ROOT/pages/vfs.adoc
@@ -32,14 +32,16 @@ ____
 
 Full pinned file::
 The file has been _hydrated_ explicitly by the user through File Explorer and is guaranteed to be available offline.
+
 Full file::
 The file has been _hydrated_ implicitly and could be _dehydrated_ by the system if space is needed.
+
 Placeholder file::
 An empty representation of the file and only available if the sync service is available.
 
 The following image demonstrates how the _full pinned_, _full_ and _placeholder_ file states are shown in File Explorer.
 
-image:vfs/vfs-ms-cloud-file-states-file-explorer.png[File States, width=50%,pdfwidth=50%]
+image::vfs/vfs-ms-cloud-file-states-file-explorer.png[File States, width=400,pdfwidth=80%]
 
 === Limitations and Restrictions
 
@@ -65,21 +67,21 @@ To set up a new synchronization with virtual file system enabled, perform the fo
 
 . Add a new synchronization by clicking the btn:[+ Add account] button.
 +
-image:vfs/vfs-add-account.png[Add Account, width=50%,pdfwidth=50%]
+image::vfs/vfs-add-account.png[Add Account, width=400,pdfwidth=80%]
 
 . Enter the server address and your credentials in the following dialogs.
 
 . Select the radio button btn:[Use virtual files] and set the local folder where your synchronization data will reside.
 +
-image:vfs/vfs-sync-type.png[Set the Sync Type, width=80%,pdfwidth=80%]
+image::vfs/vfs-sync-type.png[Set the Sync Type, width=600,pdfwidth=50%]
 
 . When everything is done, you should see a similar screen as below, showing that the setup completed successfully.
 +
-image:vfs/vfs-setup-successful.png[Setup Successful, width=80%,pdfwidth=80%]
+image::vfs/vfs-setup-successful.png[Setup Successful, width=600,pdfwidth=70%]
 
 . After the first sync, your synchronization folder will show your items with the _Placeholder_ icon.
 +
-image:vfs/vfs-setup-successful-explorer.png[Setup Successful Explorer, width=80%,pdfwidth=80%]
+image::vfs/vfs-setup-successful-explorer.png[Setup Successful Explorer, width=600,pdfwidth=80%]
 
 . When opening a file, the file gets downloaded and its synchronization icon changes to _Full_.
 
@@ -89,7 +91,7 @@ If you have full synchronization enabled, you can change to a virtual file syste
 
 . Open your existing synchronization, click the btn:[...] button and menu:Enable virtual file support[].
 +
-image:vfs/vfs-convert-to-vfs.png[Convert Full to VFS, width=80%,pdfwidth=80%]
+image::vfs/vfs-convert-to-vfs.png[Convert Full to VFS, width=600,pdfwidth=80%]
 
 . Your local files will get replaced by _placeholders_, thus freeing up the space previously occupied.
 
@@ -99,15 +101,15 @@ You can also change the synchronization setting from virtual file system to full
 
 . Open your existing synchronization, click the btn:[...] button and menu:Disable virtual file support[].
 +
-image:vfs/vfs-disable-virtual-file-support-1.png[Disable VFS 1, width=80%,pdfwidth=80%]
+image::vfs/vfs-disable-virtual-file-support-1.png[Disable VFS 1, width=600,pdfwidth=80%]
 
 . A notification window will ask you to confirm before completing the conversion.
 +
-image:vfs/vfs-disable-virtual-file-support-2.png[Disable VFS 2, width=80%,pdfwidth=80%]
+image::vfs/vfs-disable-virtual-file-support-2.png[Disable VFS 2, width=600,pdfwidth=80%]
 
 . When done, your files will be fully downloaded, which you can tell by the sync icons, see the example image below. Depending on the quantity and size of the files, this may take a while.
 +
-image:vfs/vfs-full-sync-no-vfs.png[Full Snyc No VFS, width=80%,pdfwidth=80%]
+image::vfs/vfs-full-sync-no-vfs.png[Full Snyc No VFS, width=600,pdfwidth=70%]
 
 === Manage VFS from Windows Explorer
 
@@ -117,22 +119,22 @@ You can manage `individual` files or `complete folders` in the Explorer window b
  
 . To create a Full Pinned file (have a local copy of it), use the action btn:[Always keep on this device].
 +
-image:vfs/vfs-always-keep-on-this-device.png[Always keep on this Device, width=80%,pdfwidth=80%]
+image::vfs/vfs-always-keep-on-this-device.png[Always keep on this Device, width=600,pdfwidth=80%]
 +
 The state of the file will change to synchronizing.
 +
-image:vfs/vfs-always-keep-on-this-device-syncing.png[Always keep on this Device Syncing, width=50%,pdfwidth=50%]
+image::vfs/vfs-always-keep-on-this-device-syncing.png[Always keep on this Device Syncing]
 +
 When the local copy has been created, the state (icon) changes to _Full Pinned_.
 +
-image:vfs/vfs-always-keep-on-this-device-synced.png[Always keep on this Device Syned, width=50%,pdfwidth=50%]
+image::vfs/vfs-always-keep-on-this-device-synced.png[Always keep on this Device Syned]
 
 ==== Free up Space
 
 . To free up the space the file occupied, use the action btn:[Free up space].
 +
-image:vfs/vfs-free-up-space.png[Free Up Space, width=50%,pdfwidth=50%]
+image::vfs/vfs-free-up-space.png[Free Up Space, width=400,pdfwidth=70%]
 
 . When done, Explorer will show the file in _Placeholder_ state.
 +
-image:vfs/vfs-setup-successful-explorer.png[Setup Successful Explorer, width=80%,pdfwidth=80%]
+image::vfs/vfs-setup-successful-explorer.png[Setup Successful Explorer, width=600,pdfwidth=70%]


### PR DESCRIPTION
From a legacy, it was formerly allowed to use a percent value for html when defining the width. There is a warning from Antora (also some time ago) not to use this anymore as the rendered result will not return the expected view. This PR fixes this for this repo, all images now render correctly as required.

A local build shows that all images are ok now.

In addition, some minor things have been fixed too.

Backport to 3.0 and 2.11 (for the latter we need to check if it renders correctly and if there are conflicts)