### PR TITLE
Explain cleanup of Not Synced messages

### DIFF
--- a/modules/ROOT/pages/faq.adoc
+++ b/modules/ROOT/pages/faq.adoc
@@ -3,7 +3,7 @@
 :wordpress1-url: http://petersteier.wordpress.com/2011/10/22/windows-indexer-changes-modification-dates-of-eml-files/
 :user_manual_quota: https://doc.owncloud.com/server/next/user_manual/files/webgui/quota.html
 
-:description: Here you can find some of the most frequently asked questions about the ownCloud Desktop App.
+:description: Here you can find some of the most frequently asked questions about the ownCloud Desktop app.
 
 == Introduction
 
@@ -168,4 +168,4 @@ echo 524288 > /proc/sys/fs/inotify/max_user_watches.
 
 == Messages in the 'Not Synced' Tab
 
-When the Desktop App syncronizes, it clears the message list in the btn:[Not Synced] tab before each syncronisation starts and prints the result of the current syncronisation to the tab during processing. After a full sync, incremental syncs are made and only content that is not in sync is processed. Therefore, any messages listed that got resolved do no longer appear.
+When the Desktop app synchronizes, it clears the message list in the btn:[Not Synced] tab before each synchronization starts and prints the result of the current synchronization to the tab during processing. After a full sync, incremental syncs are made and only content that is not in sync is processed. Therefore, any listed messages  that got resolved no longer appear.

--- a/modules/ROOT/pages/faq.adoc
+++ b/modules/ROOT/pages/faq.adoc
@@ -3,13 +3,15 @@
 :wordpress1-url: http://petersteier.wordpress.com/2011/10/22/windows-indexer-changes-modification-dates-of-eml-files/
 :user_manual_quota: https://doc.owncloud.com/server/next/user_manual/files/webgui/quota.html
 
+:description: Here you can find some of the most frequently asked questions about the ownCloud Desktop App.
+
 == Introduction
 
-Here you can find some of the most frequently asked questions about the ownCloud Desktop App.
+{description}
 
 == Usage
 
-=== Some Files Are Continuously Uploaded to the Server, Even When They Are Not Modified
+=== Continuous File Upload to the Server Though No Modifications Made
 
 It is possible that another program is changing the modification date of the file. If the file has an `.eml` extension (Windows Mail, Windows Live Mail), the Microsoft Indexer automatically and continually changes the file.
 To solve this issue, you can:
@@ -163,3 +165,7 @@ This problem can be solved by setting the `fs.inotify.max_user_watches sysctl` t
 ----
 echo 524288 > /proc/sys/fs/inotify/max_user_watches.
 ----
+
+== Messages in the 'Not Synced' Tab
+
+When the Desktop App syncronizes, it clears the message list in the btn:[Not Synced] tab before each syncronisation starts and prints the result of the current syncronisation to the tab during processing. After a full sync, incremental syncs are made and only content that is not in sync is processed. Therefore, any messages listed that got resolved do no longer appear.


### PR DESCRIPTION
Fixes: #324 ([FAQ] Explain cleanup of error messages)

* Add a text that explains how messages appear and disappear in the `Not Synced` tab.
* Shortended a headline for better readability
* Add the description attribute

Backpor to 3.0 and 2.11