### PR TITLE
How to fix signature verification errors

### DIFF
--- a/modules/ROOT/pages/installing.adoc
+++ b/modules/ROOT/pages/installing.adoc
@@ -106,7 +106,9 @@ On Debian-based systems, it may happen after a while that when running `sudo apt
 ----
 sudo apt-key adv --refresh-keys --keyserver keyserver.debian.org
 ----
+
 For Ubuntu, use:
+
 [source,bash]
 ----
 sudo apt-key adv --refresh-keys --keyserver keyserver.ubuntu.com

--- a/modules/ROOT/pages/installing.adoc
+++ b/modules/ROOT/pages/installing.adoc
@@ -94,11 +94,18 @@ When the extension is installed, you need to restart the GNOME shell. To do so, 
 image::installing/gnome-shell-extension-appindicator-selector.png[width=600,pdfwidth=60%]
 --
 
-==== Native installation
+==== Native Installation
 
 Linux users must follow the instructions on the {desktop-clients-url}[download] page to add the appropriate repository for their Linux distribution, install the signing key and use their package managers to install the Desktop App. Linux users will also update their Desktop App via package manager. The Desktop App will display a notification when an update is available. Note to see xref:installing-shell-integration-packages[Installing Shell Integration Packages]. Overlay icons and a special context menu for your file browsers need to be installed manually.
 
 You will also find links to source code archives and older versions on the download page.
+
+On Debian based systems, it may happen after a while that when running `sudo apt update`, a notice about a signature verification error can be returned. This can be solved by envoking following command to update all sinatures:
+
+[source,bash]
+----
+sudo apt-key adv --refresh-keys --keyserver keyserver.ubuntu.com
+----
 
 ==== AppImage
 

--- a/modules/ROOT/pages/installing.adoc
+++ b/modules/ROOT/pages/installing.adoc
@@ -104,7 +104,7 @@ On Debian-based systems, it may happen after a while that when running `sudo apt
 
 [source,bash]
 ----
-sudo apt-key adv --refresh-keys --keyserver keyserver.debian.org
+sudo apt-key adv --refresh-keys --keyserver keyring.debian.org
 ----
 
 For Ubuntu, use:

--- a/modules/ROOT/pages/installing.adoc
+++ b/modules/ROOT/pages/installing.adoc
@@ -100,7 +100,7 @@ Linux users must follow the instructions on the {desktop-clients-url}[download] 
 
 You will also find links to source code archives and older versions on the download page.
 
-On Debian based systems, it may happen after a while that when running `sudo apt update`, a notice about a signature verification error can be returned. This can be solved by envoking following command to update all sinatures:
+On Debian-based systems, it may happen after a while that when running `sudo apt update`, a notice about a signature verification error is returned. This can be solved by invoking the following command to update all signatures:
 
 [source,bash]
 ----

--- a/modules/ROOT/pages/installing.adoc
+++ b/modules/ROOT/pages/installing.adoc
@@ -100,8 +100,13 @@ Linux users must follow the instructions on the {desktop-clients-url}[download] 
 
 You will also find links to source code archives and older versions on the download page.
 
-On Debian-based systems, it may happen after a while that when running `sudo apt update`, a notice about a signature verification error is returned. This can be solved by invoking the following command to update all signatures:
+On Debian-based systems, it may happen after a while that when running `sudo apt update`, a notice about a signature verification error is returned. This can be solved by refreshing the keys. On Debian invoke the following command to update all signatures:
 
+[source,bash]
+----
+sudo apt-key adv --refresh-keys --keyserver keyserver.debian.org
+----
+For Ubuntu, use:
 [source,bash]
 ----
 sudo apt-key adv --refresh-keys --keyserver keyserver.ubuntu.com


### PR DESCRIPTION
I recently ran into the issue that when running `sudo apt update` that the command returns signature verification errors. This PR adds a note for Debian based systems how to update the signatures.

Backport to 3.1 and 3.0