### PR TITLE
[3.0] [PR 356] update desktop app testing docs for ocis

### DIFF
--- a/modules/ROOT/pages/appendices/guitest.adoc
+++ b/modules/ROOT/pages/appendices/guitest.adoc
@@ -105,7 +105,6 @@ While running the tests against Infinite Scale, playwright is used to automate t
 
 . Install {node-install-url}[node] and {pnpm-install-url}[pnpm]
 . Go to `test/gui/webUI` and run 
-[source,bash]
 +
 [source,bash]
 ----

--- a/modules/ROOT/pages/appendices/guitest.adoc
+++ b/modules/ROOT/pages/appendices/guitest.adoc
@@ -104,7 +104,19 @@ NOTE: If there are problems with starting Squish, please check the log file `~/.
 While running the tests against Infinite Scale, playwright is used to automate the login process in the browser. The following extra steps need to be taken:
 
 . Install {node-install-url}[node] and {pnpm-install-url}[pnpm]
-. Go to `test/gui/webUI` and run `pnpm install`
+. Go to `test/gui/webUI` and run 
+[source,bash]
++
+[source,bash]
+----
+pnpm install
+----
+. Install Playwright Chromium 
++
+[source,bash]
+----
+npx playwright install chromium
+----
 
 === Using Docker
 


### PR DESCRIPTION
Backport of #356