### PR TITLE
Move and update the description attribute to the correct place

### DIFF
--- a/modules/ROOT/pages/advanced_usage/command_line_client.adoc
+++ b/modules/ROOT/pages/advanced_usage/command_line_client.adoc
@@ -1,10 +1,11 @@
 = The Command Line Client
 :toc: right
+:description: The ownCloud Client packages contain a command line client, owncloudcmd, that can be used to synchronize ownCloud files to client machines.
 :page-aliases: advanced_usage/command_line_options.adoc
 
 == Introduction
 
-The ownCloud Client packages contain a command line client, `owncloudcmd`, that can be used to synchronize ownCloud files to client machines.
+{description}
 
 == Command Description
 

--- a/modules/ROOT/pages/advanced_usage/configuration_file.adoc
+++ b/modules/ROOT/pages/advanced_usage/configuration_file.adoc
@@ -1,10 +1,12 @@
 = Configuration File
-:toc:
+:toc: right
+:description: The ownCloud Desktop App uses a configuration file. It has several sections for particular settings. You will find more sections in the configuration file than described here.
+
 :ini-file-format-url: https://en.wikipedia.org/wiki/INI_file
 
 == Introduction
 
-The ownCloud Desktop App uses a configuration file. It has several sections for particular settings. You will find more sections in the configuration file than described here. Do not change any of those settings except support advises you to do so. 
+{description} Do not change any of those settings except support advises you to do so. 
 
 == Location of the Configuration File
  

--- a/modules/ROOT/pages/advanced_usage/environment_variables.adoc
+++ b/modules/ROOT/pages/advanced_usage/environment_variables.adoc
@@ -1,9 +1,10 @@
 = Environment Variables
 :toc: right
+:description: The behavior of the client can be controlled using environment variables.
 
 == Introduction
 
-The behavior of the client can also be controlled using environment variables.
+{description}
 
 NOTE: The value of the environment variables override the values in the configuration file.
 

--- a/modules/ROOT/pages/advanced_usage/low_disk_space.adoc
+++ b/modules/ROOT/pages/advanced_usage/low_disk_space.adoc
@@ -1,9 +1,10 @@
 = Low Disk Space
 :toc: right
+:description: When disk space is low, the ownCloud Desktop App will be unable to synchronize all files. This section describes its behavior in a low disk space situation as well as the adjustable environment variables that influence it.
 
 == Introduction
 
-When disk space is low, the ownCloud Desktop App will be unable to synchronize all files. This section describes its behavior in a low disk space situation as well as the adjustable environment variables that influence it.
+{description}
 
 == Cases
 

--- a/modules/ROOT/pages/appendices/architecture.adoc
+++ b/modules/ROOT/pages/appendices/architecture.adoc
@@ -1,11 +1,12 @@
 = Appendix History and Architecture
 :toc: right
+:description: ownCloud provides Desktop Apps to synchronize the contents of local directories from computers, tablets, and handheld devices to the ownCloud server.
 :page-aliases: architecture.adoc
 :theopengroup-url: http://pubs.opengroup.org/onlinepubs/009695399/utilities/xcu_chap02.html#tag_02_13_01
 
 == Introduction
 
-ownCloud provides Desktop Apps to synchronize the contents of local directories from computers, tablets, and handheld devices to the ownCloud server.
+{description}
 
 Synchronization is accomplished using http://www.csync.org[csync], a bidirectional file synchronizing tool that provides both a command line client and a library.
 A special module for csync was written to synchronize with the ownCloud built-in WebDAV server.

--- a/modules/ROOT/pages/appendices/building.adoc
+++ b/modules/ROOT/pages/appendices/building.adoc
@@ -1,4 +1,8 @@
 = Appendix Building the Desktop App
+:toc: right
+:description: This section explains how to build the Desktop App from source for all major platforms.
+:page-aliases: building.adoc
+
 :kde-craft-url: https://community.kde.org/Craft
 :kde-craft-build-from-source-url: https://community.kde.org/Guidelines_and_HOWTOs/Build_from_source/Windows
 :install-powershell-url: https://docs.microsoft.com/en-us/powershell/scripting/install/installing-windows-powershell?view=powershell-6
@@ -16,13 +20,10 @@
 :macports-url: http://www.macports.org
 :owncloud-obs: http://software.opensuse.org/download/package?project=isv:ownCloud:desktop&package=owncloud-client
 :opensuse-url: http://download.opensuse.org/repositories/isv:/ownCloud:/desktop/
-:page-aliases: building.adoc
 
 == Introduction
 
-This section explains how to build the link:https://owncloud.org/download/#owncloud-desktop-client[ownCloud Desktop App] from source for all major platforms.
-You should read this section if you want to develop for the Desktop App.
-Build instructions are subject to change as development proceeds.
+{description} Here you can finde the source of the link:https://owncloud.org/download/#owncloud-desktop-client[ownCloud Desktop App]. You should read this section if you want to develop for the Desktop App. Build instructions are subject to change as development proceeds.
 
 NOTE: Please check the version for which you want to build.
 

--- a/modules/ROOT/pages/appendices/guitest.adoc
+++ b/modules/ROOT/pages/appendices/guitest.adoc
@@ -1,6 +1,7 @@
 = GUI Testing the Desktop App
 :toc: right
 :toclevels: 3
+:description: This document explains how to run GUI tests for the Desktop App locally in your system.
 
 :squish-url: https://www.froglogic.com/squish/download/
 :free-trial-url: https://www.froglogic.com/squish/free-trial/
@@ -18,7 +19,7 @@
 
 == Introduction
 
-This document explains how to run GUI tests for the Desktop App locally in your system. To run GUI tests, the Squish GUI Test Automation Tool for all kinds of cross-platform desktop, mobile, embedded and web applications is used.
+{description} To run GUI tests, the Squish GUI Test Automation Tool for all kinds of cross-platform desktop, mobile, embedded and web applications is used.
 
 == Prerequisites
 

--- a/modules/ROOT/pages/appendices/troubleshooting.adoc
+++ b/modules/ROOT/pages/appendices/troubleshooting.adoc
@@ -1,16 +1,18 @@
 = Appendix Troubleshooting
 :toc: right
+:description: When reporting bugs, it is helpful if you first determine what part of the system is causing the issue.
 :page-aliases: troubleshooting.adoc
+
 :files-antivirus-app-url: https://github.com/owncloud/files_antivirus
 
 == Introduction
+
+{description}
 
 The following two general issues can result in failed synchronization:
 
 * The server setup is incorrect.
 * The Desktop App contains a bug.
-
-When reporting bugs, it is helpful if you first determine what part of the system is causing the issue.
 
 == Identifying Basic Functionality Problems
 

--- a/modules/ROOT/pages/automatic_updater.adoc
+++ b/modules/ROOT/pages/automatic_updater.adoc
@@ -1,9 +1,10 @@
 = Automatic Updating of the Desktop App
 :toc: right
+:description: The Automatic Updater ensures that you always have the latest features and bug fixes for your ownCloud Desktop App.
 
 == Introduction
 
-The Automatic Updater ensures that you always have the latest features and bug fixes for your ownCloud Desktop App. The Automatic Updater updates only on Mac OS X and Windows computers; Linux users only need to use their normal package managers. However, on Linux systems the Updater will check for updates and notify you when a new version is available.
+{description} The Automatic Updater updates only on Mac OS X and Windows computers; Linux users only need to use their normal package managers. However, on Linux systems the Updater will check for updates and notify you when a new version is available.
 
 == Basic Workflow
 

--- a/modules/ROOT/pages/conflicts.adoc
+++ b/modules/ROOT/pages/conflicts.adoc
@@ -1,10 +1,11 @@
 = Manage Synchronisation Conflicts
 :toc: right
 :toclevels: 1
+:description: The ownCloud Desktop App uploads local changes and downloads remote changes. When a file has changed on the local and on the remote side between synchronization runs, the Desktop App will be unable to resolve the situation on its own.
 
 == Introduction
 
-The ownCloud Desktop App uploads local changes and downloads remote changes. When a file has changed on the local and on the remote side between synchronization runs, the Desktop App will be unable to resolve the situation on its own. It will create a conflict file with the local version, downloads the remote version and notifies the user that a conflict occurred which needs attention.
+{description} It will create a conflict file with the local version, downloads the remote version and notifies the user that a conflict occurred which needs attention.
 
 == Example Situation
 

--- a/modules/ROOT/pages/faq.adoc
+++ b/modules/ROOT/pages/faq.adoc
@@ -1,9 +1,9 @@
 = Desktop Frequently Asked Questions (FAQ)
 :toc: right
+:description: Here you can find some of the most frequently asked questions about the ownCloud Desktop app.
+
 :wordpress1-url: http://petersteier.wordpress.com/2011/10/22/windows-indexer-changes-modification-dates-of-eml-files/
 :user_manual_quota: https://doc.owncloud.com/server/next/user_manual/files/webgui/quota.html
-
-:description: Here you can find some of the most frequently asked questions about the ownCloud Desktop app.
 
 == Introduction
 

--- a/modules/ROOT/pages/filenames.adoc
+++ b/modules/ROOT/pages/filenames.adoc
@@ -1,10 +1,12 @@
 = Filename Considerations
 :toc: right
+:description: When using the Desktop App, depending on the operating system (OS) you are using, file and folder names can have different restrictions.
+
 :control_code_chart-url: https://en.wikipedia.org/wiki/ASCII#Control_code_chart
 
 == Introduction
 
-When using the Desktop App, depending on the operating system (OS) you are using, file and folder names can have different restrictions. Creating files and folders with allowed names on one OS, may have issues or even can´t be synced because of different rules in another OS. This page gives you a brief overview of limitations of different OS for file and folder names.
+{description} Creating files and folders with allowed names on one OS, may have issues or even can´t be synced because of different rules in another OS. This page gives you a brief overview of limitations of different OS for file and folder names.
 
 NOTE: This is not an ownCloud rule but an OS dependency
 

--- a/modules/ROOT/pages/installing.adoc
+++ b/modules/ROOT/pages/installing.adoc
@@ -1,6 +1,8 @@
 = Installing the Desktop App
 :toc: right
 :toclevels: 4
+:description: The Desktop App enables users to access and sync files and folders from their ownCloud, work on remote files right from the desktop as if they were stored on their computer – because they are.
+
 :ms-remove-url: https://docs.microsoft.com/en-us/windows/win32/msi/remove
 :ms-adddefault-url: https://docs.microsoft.com/en-us/windows/win32/msi/adddefault
 :desktop-clients-url: https://owncloud.com/desktop-app/
@@ -13,12 +15,11 @@
 :gnome-extensions-url: https://extensions.gnome.org/extension/615/appindicator-support/
 :appimagelauncher-url: https://docs.appimage.org/introduction/software-overview.html#ref-appimagelauncher
 :install-appimagelauncher-url: https://github.com/TheAssassin/AppImageLauncher/wiki
-:description: The Desktop App enables users to access and sync files and folders from their ownCloud, work on remote files right from the desktop as if they were stored on their computer – because they are. Continuous synchronization to and from the ownCloud server provides ease of use combined with comprehensive access control.
 :install-shell-integration-url: https://github.com/owncloud/client-desktop-install-shell-integration
 
 == Introduction
 
-{description}
+{description} Continuous synchronization to and from the ownCloud server provides ease of use combined with comprehensive access control.
 
 == System Requirements and Installation
 

--- a/modules/ROOT/pages/navigating.adoc
+++ b/modules/ROOT/pages/navigating.adoc
@@ -1,9 +1,9 @@
 = Using the Desktop App
 :toc: right
 :toclevels: 2
-:oauth2-app-url: https://marketplace.owncloud.com/apps/oauth2
-
 :description: The ownCloud Desktop App remains in the background and is visible as an icon in the system tray (Windows, KDE), menu bar (macOS), or notification area (Linux).
+
+:oauth2-app-url: https://marketplace.owncloud.com/apps/oauth2
 
 == Introduction
 

--- a/modules/ROOT/pages/vfs.adoc
+++ b/modules/ROOT/pages/vfs.adoc
@@ -1,10 +1,10 @@
 = Using the Virtual Filesystem
 :toc: right
+:description: ownCloud offers the possibility for users to enable a virtual file system (VFS) when synchronizing data.
+
 :wikipedia-url: https://en.wikipedia.org/wiki/Virtual_file_system
 :placeholder-files-url: https://docs.microsoft.com/en-us/windows/win32/cfapi/build-a-cloud-file-sync-engine
 :onedrive-restrictions-url: https://support.microsoft.com/en-us/office/restrictions-and-limitations-in-onedrive-and-sharepoint-64883a5d-228e-48f5-b3d2-eb39e07630fa?ui=en-US&rs=en-US&ad=US#filenamepathlengths
-
-:description: ownCloud offers the possibility for users to enable a virtual file system (VFS) when synchronizing data.
 
 == Introduction
 

--- a/modules/ROOT/pages/web_app.adoc
+++ b/modules/ROOT/pages/web_app.adoc
@@ -1,6 +1,5 @@
 = Open Files with Office Web Apps
 :toc: right
-
 :description: When using Infinite Scale, you can open and edit synced office files locally using office web apps.
 
 == Introduction


### PR DESCRIPTION
**This is no content change !**

When using the attribute `:description:` which creates a meta tag in htm for search engines when rendered, you need to use two rules:

* It must be under the section header, not in aprticular order, but without a blank line above
* You must not use any links or attributes like `xref:{url}[text]` - will not get resolved and taken as it is

Found by chance. This PR corrects this for the docs-client-desktop repo.

This will now make search engines print predefined text more likely than before when returning search results.

Backport to 3.2 and 3.1