### PR TITLE
Bring back lost OCC_UPDATE_URL

### DIFF
--- a/modules/ROOT/pages/advanced_usage/environment_variables.adoc
+++ b/modules/ROOT/pages/advanced_usage/environment_variables.adoc
@@ -150,4 +150,8 @@ Set to -1 to never require full local discovery.
 | `OWNCLOUD_OVERRIDE_SERVER_URL`
 | unset
 | Set to override a previously configured/branded server URL
+
+| `OCC_UPDATE_URL`
+| unset
+| This value can be set in the environment of the client to let the client choose a different update URL for testing purposes. 
 |===


### PR DESCRIPTION
Seems this got lost over time…

Related:
https://github.com/owncloud/client/issues/3834