### PR TITLE
Fix system requirements for 4.1 release

### DIFF
--- a/modules/ROOT/pages/installing.adoc
+++ b/modules/ROOT/pages/installing.adoc
@@ -53,7 +53,7 @@ macOS::
 Linux::
 * Debian 11 & 12 (x86-64)
 * Fedora 36 & 37 & 38 (x86-64)
-* openSUSE Leap 15.4 & 15.5 (x86-64)
+* openSUSE Leap 15.4 (x86-64)
 * Ubuntu 22.04 & 22.10 & 23.04 (x86-64)
 * **{appimage-wikipedia-url}[AppImage]** build of the ownCloud Desktop App is available to support more Linux platforms
 


### PR DESCRIPTION
openSUSE Leap 15.5 is not going to be included in the upcoming 4.1 release but should be re-included in 5.0.

