### PR TITLE
Using owncloudcmd from AppImage

### DIFF
--- a/modules/ROOT/pages/advanced_usage/command_line_client.adoc
+++ b/modules/ROOT/pages/advanced_usage/command_line_client.adoc
@@ -118,7 +118,7 @@ To synchronize the ownCloud directory `Music` to the local directory `media/musi
 ----
 ./owncloudcmd --httpproxy http://192.168.178.1:8080 \
               $HOME/media/music \
-              https://server/owncloud/remote.php/dav/files/carla \
+              https://server/owncloud/remote.php/dav/files/carla/ \
               /Music.
 ----
 

--- a/modules/ROOT/pages/advanced_usage/command_line_client.adoc
+++ b/modules/ROOT/pages/advanced_usage/command_line_client.adoc
@@ -85,6 +85,9 @@ Following options are supported by `owncloudcmd`:
 | `--downlimit <n>`
 | Limit the download speed of files to n KB/s
 
+| `--sync-hidden-files`
+| Enables synchronization of hidden files
+
 | `--logdebug`
 | More verbose logging
 

--- a/modules/ROOT/pages/advanced_usage/command_line_client.adoc
+++ b/modules/ROOT/pages/advanced_usage/command_line_client.adoc
@@ -10,7 +10,7 @@
 
 `owncloudcmd` performs a single _sync run_ and then exits the synchronization process. In this manner, `owncloudcmd` processes the differences between client and server directories and propagates the files to bring both repositories to the same state. Contrary to the GUI-based client, `owncloudcmd` does not repeat synchronizations on its own. It also does not monitor for file system changes.
 
-To invoke `owncloudcmd`, you must provide the local and the remote repository URL using the following command, the example is based on Windows:
+To invoke `owncloudcmd`, you must provide the local and the remote repository URL using the following command. Note that for Windows, you must be in the directory where ownCloud is installed while on Linux, you can use the command from anywhere. To show its location in Linux, type `whereis owncloudcmd`.
 
 [source,console]
 ----
@@ -107,7 +107,7 @@ The following options are supported by `owncloudcmd`:
 
 [source,bash]
 ----
-./owncloudcmd /home/user/my_sync_folder \
+owncloudcmd /home/user/my_sync_folder \
               https://carla:secret@server/owncloud/remote.php/dav/files/carla/ \
               /
 ----
@@ -116,7 +116,7 @@ To synchronize the ownCloud directory `Music` to the local directory `media/musi
 
 [source,console]
 ----
-./owncloudcmd --httpproxy http://192.168.178.1:8080 \
+owncloudcmd --httpproxy http://192.168.178.1:8080 \
               $HOME/media/music \
               https://server/owncloud/remote.php/dav/files/carla/ \
               /Music.

--- a/modules/ROOT/pages/advanced_usage/command_line_client.adoc
+++ b/modules/ROOT/pages/advanced_usage/command_line_client.adoc
@@ -17,7 +17,7 @@ To invoke `owncloudcmd`, you must provide the local and the remote repository UR
 owncloudcmd [options] [arguments]
 ----
 
-For the arguments, all of them must be used in the following order, replace the placeholders with real data: 
+Regarding the arguments, all of them must be used in the following order and the placeholders replaced with real data: 
 
 [source,plaintext]
 ----
@@ -39,7 +39,7 @@ source_dir server_url remote_folder
 | The remote folder on the server.
 |===
 
-Following options are supported by `owncloudcmd`:
+The following options are supported by `owncloudcmd`:
 
 [width="100%",cols="35%,65%",options="header"]
 |===
@@ -130,7 +130,7 @@ To synchronize the ownCloud directory `Music` to the local directory `media/musi
 
 == Command Line Client When Using AppImages
 
-When using an xref:installing.adoc#appimage[AppImage] installation with Linux, there is no `owncloudcmd` command you can start but the name of the AppImage. To use the command line client of the AppImage, just use the name of the AppImage and append the `--cmd` option plus all other parameters as listed in the xref:#command-description[Command Description]. Replace `[...]` with the version you are using or take the name of the AppImage if you have renamed it otherwise. Example:
+When using an xref:installing.adoc#appimage[AppImage] installation with Linux, there is no `owncloudcmd` command you can start but the name of the AppImage. To use the command line client of the AppImage, just use the name of the AppImage and append the `--cmd` option plus all other parameters as listed in the xref:#command-description[Command Description]. Replace `[...]` with the version you are using or take the name of the AppImage if you have named it otherwise. Example:
 
 [source,bash]
 ----

--- a/modules/ROOT/pages/advanced_usage/command_line_client.adoc
+++ b/modules/ROOT/pages/advanced_usage/command_line_client.adoc
@@ -1,6 +1,6 @@
 = The Command Line Client
 :toc: right
-:description: The ownCloud Client packages contain a command line client, owncloudcmd, that can be used to synchronize ownCloud files to client machines.
+:description: The ownCloud Client packages contain a command line client, owncloudcmd, that can be used to synchronize ownCloud files to client machines from the command line.
 
 == Introduction
 
@@ -10,22 +10,40 @@
 
 `owncloudcmd` performs a single _sync run_ and then exits the synchronization process. In this manner, `owncloudcmd` processes the differences between client and server directories and propagates the files to bring both repositories to the same state. Contrary to the GUI-based client, `owncloudcmd` does not repeat synchronizations on its own. It also does not monitor for file system changes.
 
-To invoke `owncloudcmd`, you must provide the local and the remote repository URL using the following command:
+To invoke `owncloudcmd`, you must provide the local and the remote repository URL using the following command, the example is based on Windows:
 
 [source,console]
 ----
-owncloudcmd [options] source_dir server_url remote_folder.
+owncloudcmd [options] [arguments]
 ----
 
-* `sourcedir` is the local directory,
-* `owncloudurl` is the server URL and
-* `remote_folder` is a remote folder.
+For the arguments, all of them must be used in the following order, replace the placeholders with real data: 
 
-Other command line switches supported by `owncloudcmd` include the following:
+[source,plaintext]
+----
+source_dir server_url remote_folder
+----
 
 [width="100%",cols="35%,65%",options="header"]
 |===
-| Switch
+| Arguments
+| Description
+
+| `source_dir`
+| This is the local directory.
+
+| `server_url`
+| This is the server URL.
+
+| `remote_folder`
+| The remote folder on the server.
+|===
+
+Following options are supported by `owncloudcmd`:
+
+[width="100%",cols="35%,65%",options="header"]
+|===
+| Option
 | Description
 
 | `-s, --silent`
@@ -82,20 +100,23 @@ Other command line switches supported by `owncloudcmd` include the following:
 
 == Credential Handling
 
-`owncloudcmd` requires the user to specify the username and password using the standard URL pattern, for example:
+`owncloudcmd` requires the user to specify the username and password using the standard URL pattern. The example is based on Linux and uses ownCloud Server as backend:
 
-[source,console]
+[source,bash]
 ----
-$ owncloudcmd /home/user/my_sync_folder https://carla:secret@server/owncloud/remote.php/dav/files/carla/
+./owncloudcmd /home/user/my_sync_folder \
+              https://carla:secret@server/owncloud/remote.php/dav/files/carla/ \
+              /
 ----
 
 To synchronize the ownCloud directory `Music` to the local directory `media/music`, through a proxy listening on port `8080`, and on a gateway machine using IP address `192.168.178.1`, the command line would be:
 
 [source,console]
 ----
-$ owncloudcmd --httpproxy http://192.168.178.1:8080 \
+./owncloudcmd --httpproxy http://192.168.178.1:8080 \
               $HOME/media/music \
-              https://server/owncloud/remote.php/dav/files/carla/Music.
+              https://server/owncloud/remote.php/dav/files/carla \
+              /Music.
 ----
 
 `owncloudcmd` will prompt for the username and password, unless they have been specified on the command line or `-n` has been passed.
@@ -103,3 +124,12 @@ $ owncloudcmd --httpproxy http://192.168.178.1:8080 \
 == Exclude List
 
 `owncloudcmd` requires access to an exclude list file. It must either be installed along with `owncloudcmd` and thus be available in a system location, be placed next to the binary as `sync-exclude.lst` or be explicitly specified with the `--exclude` switch.
+
+== Command Line Client When Using AppImages
+
+When using an xref:installing.adoc#appimage[AppImage] installation with Linux, there is no `owncloudcmd` command you can start but the name of the AppImage. To use the command line client of the AppImage, just use the name of the AppImage and append the `--cmd` option plus all other parameters as listed in the xref:#command-description[Command Description]. Replace `[...]` with the version you are using or take the name of the AppImage if you have renamed it otherwise. Example:
+
+[source,bash]
+----
+./ownCloud-[...]-x86_64.AppImage --cmd --help
+----

--- a/modules/ROOT/pages/advanced_usage/command_line_parameters.adoc
+++ b/modules/ROOT/pages/advanced_usage/command_line_parameters.adoc
@@ -5,7 +5,7 @@
 
 == Introduction
 
-{description}
+{description} These parameters are valid for both the native and the Linux AppImage xref:installing.adoc#system-requirements-and-installation[installation].
 
 == Command Description
 


### PR DESCRIPTION
Fixes: #427 ([4.1] [owncloudcmd] from [AppImage])

This PR implements how to use `owncloudcmd` when the Desktop App is installed as AppImage.

Additionally some cleanups and corrections have been made that are aligned with options, arguments, descriptions and commands.

Backport to 4.1 only