### PR TITLE
Drop .netrc support

### DIFF
--- a/modules/ROOT/pages/advanced_usage/command_line_client.adoc
+++ b/modules/ROOT/pages/advanced_usage/command_line_client.adoc
@@ -70,9 +70,6 @@ The following options are supported by `owncloudcmd`:
 | `-p, --password <password>` 
 | Use [pass] as password
 
-| `-n`
-| Use netrc (5) for login
-
 | `--non-interactive`
 | Do not block execution with interaction
 


### PR DESCRIPTION
Fixes: #404 (.netrc support dropped (for 5.0))

As the title says...

NO Backport, master only.