### PR TITLE
Update using.adoc - fix missing commit

### DIFF
--- a/modules/ROOT/pages/using.adoc
+++ b/modules/ROOT/pages/using.adoc
@@ -367,7 +367,7 @@ Enabling this feature will affect all new transfers (next upload chunk or next d
 
 You might have some local files or directories that you do not want to backup and store on the server. To identify and exclude these files or directories, you can use the menu:Settings[Advanced > Ignored Files Editor].
 
-NOTE: rules for ignored files are also applied to folders.
+NOTE: Note that rules for ignored files are also applied to folders.
 
 image::using/ignored_files_editor.png[Ingnored Files Editor,width=350,pdfwidth=60%]
 


### PR DESCRIPTION
References #460 

For unknown reasons, the change did not make it into the main PR. The backports are already fixed.