### PR TITLE
Prefer NTFS for Windows

### DIFF
--- a/modules/ROOT/pages/installing.adoc
+++ b/modules/ROOT/pages/installing.adoc
@@ -43,7 +43,8 @@ Depending on the operating system used, some minimum system requirements need to
 
 Windows::
 * Windows 8 or later (x64)
-** For xref:vfs.adoc[VFS support], Windows 10 versions 1709 or later.
+** When using external drives storing the synchronisation data, it is highly recommended to format these drives with NTFS and not with FAT. This is because the FAT filesystem as many limitations which can cause unexpected or unwanted behaviour.
+** For xref:vfs.adoc[VFS support], Windows 10 versions 1709 or later. When using external drives,  NTFS is required.
 
 macOS::
 * macOS 10.13+

--- a/modules/ROOT/pages/installing.adoc
+++ b/modules/ROOT/pages/installing.adoc
@@ -43,8 +43,8 @@ Depending on the operating system used, some minimum system requirements need to
 
 Windows::
 * Windows 8 or later (x64)
-** When using external drives storing the synchronisation data, it is highly recommended to format these drives with NTFS and not with FAT. This is because the FAT filesystem has many limitations which can cause unexpected or unwanted behaviour.
-** For xref:vfs.adoc[VFS support], Windows 10 versions 1709 or later. When using external drives,  NTFS is required.
+** When using external drives storing the synchronization data, it is highly recommended to format these drives with NTFS and not with FAT. This is because the FAT filesystem has many limitations which can cause unexpected or unwanted behavior.
+** For xref:vfs.adoc[VFS support], Windows 10 versions 1709 or later. When using external drives, NTFS is required.
 
 macOS::
 * macOS 10.13+

--- a/modules/ROOT/pages/installing.adoc
+++ b/modules/ROOT/pages/installing.adoc
@@ -43,7 +43,7 @@ Depending on the operating system used, some minimum system requirements need to
 
 Windows::
 * Windows 8 or later (x64)
-** When using external drives storing the synchronisation data, it is highly recommended to format these drives with NTFS and not with FAT. This is because the FAT filesystem as many limitations which can cause unexpected or unwanted behaviour.
+** When using external drives storing the synchronisation data, it is highly recommended to format these drives with NTFS and not with FAT. This is because the FAT filesystem has many limitations which can cause unexpected or unwanted behaviour.
 ** For xref:vfs.adoc[VFS support], Windows 10 versions 1709 or later. When using external drives,  NTFS is required.
 
 macOS::


### PR DESCRIPTION
Fixes: #90 (NTFS is mandatory with Windows, FAT (or derivates) are not working properly)

This adds some text to the Windows prerequisites preferring NTFS over FAT.

Backport to 4.0 and 4.1