### PR TITLE
Clarify terms, query intervals and impacts

### DIFF
--- a/modules/ROOT/pages/advanced_usage/configuration_file.adoc
+++ b/modules/ROOT/pages/advanced_usage/configuration_file.adoc
@@ -43,7 +43,7 @@ about the terms. Note that the default values are always set and used unless you
 | `remotePollInterval` 
 | `30000` +
 (30s)
-| The interval in milliseconds the Desktop app polls the server for changed data. If not set explicitly via the Desktop app, the Desktop app queries the server if a server-side default is present. 
+| The interval in milliseconds the Desktop app polls the server for changes. If not set explicitly via the Desktop app, the Desktop app queries the server if a server-side default is present. 
 
 | `forceSyncInterval` 
 | `7200000` +
@@ -58,7 +58,7 @@ about the terms. Note that the default values are always set and used unless you
 | `notificationRefreshInterval` 
 | `300000` +
 (30s)
-| The interval in milliseconds in which the Desktop app checks for new server notifications. 
+| The interval in milliseconds in which the Desktop app checks the server for new notifications. 
 |===
 
 == Section `[General]`

--- a/modules/ROOT/pages/advanced_usage/configuration_file.adoc
+++ b/modules/ROOT/pages/advanced_usage/configuration_file.adoc
@@ -42,7 +42,7 @@ See the xref:faq.adoc#clarification-of-terms-used[Clarification of Terms Used] f
 | `remotePollInterval` 
 | `30000` +
 (30s)
-| The interval in milliseconds the Desktop app polls the server for changes. If not set explicitly via the Desktop app, the Desktop app queries the server if a server-side default is present. 
+| The interval in milliseconds after the last sync the Desktop app polls the server for changes. If not set explicitly via the Desktop app, the Desktop app queries the server if a server-side default is present. 
 
 | `forceSyncInterval` 
 | `7200000` +

--- a/modules/ROOT/pages/advanced_usage/configuration_file.adoc
+++ b/modules/ROOT/pages/advanced_usage/configuration_file.adoc
@@ -32,7 +32,7 @@ WARNING: Use caution when making changes to the ownCloud Desktop App configurati
 == Section `[ownCloud]`
 
 See the xref:faq.adoc#clarification-of-terms-used[Clarification of Terms Used] to get an indepth explanation
-about the terms. Note that except one wants to set different values, the defaults are always present and used.
+about the terms. Note that the default values are always set and used unless you change them.
 
 [width="100%",cols="45%,^25%,100%",options="header"]
 |===
@@ -43,22 +43,22 @@ about the terms. Note that except one wants to set different values, the default
 | `remotePollInterval` 
 | `30000` +
 (30s)
-| The interval in milliseconds the Desktop app polls the server for changed data. If not set explicitly via the Desktop app, the Desktop app queries the server for a server sided default if present. 
+| The interval in milliseconds the Desktop app polls the server for changed data. If not set explicitly via the Desktop app, the Desktop app queries the server if a server-side default is present. 
 
 | `forceSyncInterval` 
 | `7200000` +
 (2h)
-| The interval in milliseconds after which a synchronization is triggered automatically if no regular synchronisation activity took place. This enforcement takes care that there is a mandatory synchronisation independent of the servers polling response.
+| The interval in milliseconds after which a synchronization is triggered automatically if no regular synchronization activity took place. This enforcement ensures that there is a mandatory synchronization independent of the server's polling response.
 
 | `fullLocalDiscoveryInterval` 
 | `3600000` +
 (1h)
-| The interval in milliseconds after which the Desktop app will perform a full local discovery. Any changes found trigger a synchronisation.
+| The interval in milliseconds after which the Desktop app will perform a full local discovery. Any changes found trigger a synchronization.
 
 | `notificationRefreshInterval` 
 | `300000` +
 (30s)
-| The interval in milliseconds where the Desktop app checks for new server notifications. 
+| The interval in milliseconds in which the Desktop app checks for new server notifications. 
 |===
 
 == Section `[General]`

--- a/modules/ROOT/pages/advanced_usage/configuration_file.adoc
+++ b/modules/ROOT/pages/advanced_usage/configuration_file.adoc
@@ -56,7 +56,7 @@ See the xref:faq.adoc#clarification-of-terms-used[Clarification of Terms Used] f
 
 | `notificationRefreshInterval` 
 | `300000` +
-(30s)
+(5min)
 | The interval in milliseconds in which the Desktop app checks the server for new notifications. 
 |===
 

--- a/modules/ROOT/pages/advanced_usage/configuration_file.adoc
+++ b/modules/ROOT/pages/advanced_usage/configuration_file.adoc
@@ -31,29 +31,39 @@ WARNING: Use caution when making changes to the ownCloud Desktop App configurati
 
 == Section `[ownCloud]`
 
-[width="100%",cols="45%,25%,100%",options="header"]
+See the xref:faq.adoc#clarification-of-terms-used[Clarification of Terms Used] to get an indepth explanation
+about the terms. Note that except one wants to set different values, the defaults are always present and used.
+
+[width="100%",cols="45%,^25%,100%",options="header"]
 |===
-|  Variable | Default | Meaning 
+| Variable
+| Default
+| Meaning 
+
 | `remotePollInterval` 
-| `30000` 
-| Specifies the poll time for the remote repository in milliseconds.
+| `30000` +
+(30s)
+| The interval in milliseconds the Desktop app polls the server for changed data. If not set explicitly via the Desktop app, the Desktop app queries the server for a server sided default if present. 
 
 | `forceSyncInterval` 
-| `7200000` 
-| The duration of no activity after which a synchronization run shall be triggered automatically.
+| `7200000` +
+(2h)
+| The interval in milliseconds after which a synchronization is triggered automatically if no regular synchronisation activity took place. This enforcement takes care that there is a mandatory synchronisation independent of the servers polling response.
 
 | `fullLocalDiscoveryInterval` 
-| `3600000` 
-| The interval after which the next synchronization will perform a full local discovery.
+| `3600000` +
+(1h)
+| The interval in milliseconds after which the Desktop app will perform a full local discovery. Any changes found trigger a synchronisation.
 
 | `notificationRefreshInterval` 
-| `300000` 
-| Specifies the default interval of checking for new server notifications in milliseconds. 
+| `300000` +
+(30s)
+| The interval in milliseconds where the Desktop app checks for new server notifications. 
 |===
 
 == Section `[General]`
 
-[width="100%",cols="45%,25%,100%",options="header"]
+[width="100%",cols="45%,^25%,100%",options="header"]
 |===
 | Variable | Default | Meaning 
 
@@ -105,7 +115,7 @@ It does enable user interface options that can be used to opt in to experimental
 
 == Section `[Proxy]` 
 
-[width="100%",cols="45%,25%,100%",options="header"]
+[width="100%",cols="45%,^25%,100%",options="header"]
 |===
 | Variable 
 | Default 

--- a/modules/ROOT/pages/advanced_usage/configuration_file.adoc
+++ b/modules/ROOT/pages/advanced_usage/configuration_file.adoc
@@ -31,8 +31,7 @@ WARNING: Use caution when making changes to the ownCloud Desktop App configurati
 
 == Section `[ownCloud]`
 
-See the xref:faq.adoc#clarification-of-terms-used[Clarification of Terms Used] to get an indepth explanation
-about the terms. Note that the default values are always set and used unless you change them.
+See the xref:faq.adoc#clarification-of-terms-used[Clarification of Terms Used] for an in-depth explanation. Note that the default values are always set and used unless you change them.
 
 [width="100%",cols="45%,^25%,100%",options="header"]
 |===

--- a/modules/ROOT/pages/faq.adoc
+++ b/modules/ROOT/pages/faq.adoc
@@ -12,7 +12,7 @@
 == Clarification of Terms Used
 
 * *Polling* +
-Polling is defined as the task where the Desktop app queries the server for changes. If the server responds with a change that had happened on the backend, the client will start syncing the changes after polling has finished. If there is a proxy configured, it can happen that the proxy does not return actual changes but a cached state.
+Polling is defined as the task where the Desktop app queries the server for changes. If the server responds with a change that had happened on the backend, the client will start syncing the changes after polling has finished.
 
 * *Sync* +
 Syncing is defined as the task where any changes will be synchronized, no matter if they occurred in the Desktop app or on the server side. Syncing does not depend on former polling while polling can result in a sync.

--- a/modules/ROOT/pages/faq.adoc
+++ b/modules/ROOT/pages/faq.adoc
@@ -9,6 +9,17 @@
 
 {description}
 
+== Clarification of Terms Used
+
+* *Polling* +
+Polling is defined as the task where the Desktop app queries the server for changes. If the server responds with a change that had happend on the backend, the client will start syncing the changes after polling has finished. Note that when there is a proxy configured, it can happen that the proxy does not return actual changes but a cached state.
+
+* *Syncing* +
+Syncing is defined as task where any changes, independent if occured at the Desktop app or on the service side will be synchronized. If syncing is enforced, it is not dependent on former polling.
+
+* *Local Discovery* +
+Local discovery is defined as task where the Desktop app looks for changes on the local filesystem. A local discovery can internally be enforced to check for changes that have been missed like when the Desktop app was shut down during changes happened on the local filesystem. Any changes identified on the local filesystem trigger a sync after local discovery has finished.
+
 == VFS for Windows Server
 
 Without claim of completeness, actuality or support, Windows Server releases that are based on builds starting with 1709 should come with the native system API that is required to use VFS. Windows Servers 2016 and lower do not have native VFS included and will not be able to use VFS therefore.

--- a/modules/ROOT/pages/faq.adoc
+++ b/modules/ROOT/pages/faq.adoc
@@ -12,7 +12,7 @@
 == Clarification of Terms Used
 
 * *Polling* +
-Polling is defined as the task where the Desktop app queries the server for changes. If the server responds with a change that had happened on the backend, the client will start syncing the changes after polling has finished.
+Polling is defined as the task where the Desktop app queries the server for changes - among other things. If the server responds with a change that had happened on the backend, the client will start syncing the changes after polling has finished.
 
 * *Sync* +
 Syncing is defined as the task where any changes will be synchronized, no matter if they occurred in the Desktop app or on the server side. Syncing does not depend on former polling while polling can result in a sync.

--- a/modules/ROOT/pages/faq.adoc
+++ b/modules/ROOT/pages/faq.adoc
@@ -12,13 +12,13 @@
 == Clarification of Terms Used
 
 * *Polling* +
-Polling is defined as the task where the Desktop app queries the server for changes. If the server responds with a change that had happend on the backend, the client will start syncing the changes after polling has finished. Note that when there is a proxy configured, it can happen that the proxy does not return actual changes but a cached state.
+Polling is defined as the task where the Desktop app queries the server for changes. If the server responds with a change that had happened on the backend, the client will start syncing the changes after polling has finished. If there is a proxy configured, it can happen that the proxy does not return actual changes but a cached state.
 
 * *Syncing* +
-Syncing is defined as task where any changes, independent if occured at the Desktop app or on the service side will be synchronized. If syncing is enforced, it is not dependent on former polling.
+Syncing is defined as the task where any changes will be synchronized, no matter if they occurred in the Desktop app or on the service side. If syncing is enforced, it does not depend on former polling.
 
 * *Local Discovery* +
-Local discovery is defined as task where the Desktop app looks for changes on the local filesystem. A local discovery can internally be enforced to check for changes that have been missed like when the Desktop app was shut down during changes happened on the local filesystem. Any changes identified on the local filesystem trigger a sync after local discovery has finished.
+Local discovery is defined as the task where the Desktop app looks for changes on the local filesystem. A local discovery can internally be enforced to check for changes that have been missed for example when the Desktop app was shut down during ongoing changes on the local filesystem. Any changes identified on the local filesystem trigger a sync after local discovery has finished.
 
 == VFS for Windows Server
 

--- a/modules/ROOT/pages/faq.adoc
+++ b/modules/ROOT/pages/faq.adoc
@@ -14,7 +14,7 @@
 * *Polling* +
 Polling is defined as the task where the Desktop app queries the server for changes. If the server responds with a change that had happened on the backend, the client will start syncing the changes after polling has finished. If there is a proxy configured, it can happen that the proxy does not return actual changes but a cached state.
 
-* *Syncing* +
+* *Sync* +
 Syncing is defined as the task where any changes will be synchronized, no matter if they occurred in the Desktop app or on the server side. If syncing is enforced, it does not depend on former polling.
 
 * *Local Discovery* +

--- a/modules/ROOT/pages/faq.adoc
+++ b/modules/ROOT/pages/faq.adoc
@@ -15,7 +15,7 @@
 Polling is defined as the task where the Desktop app queries the server for changes. If the server responds with a change that had happened on the backend, the client will start syncing the changes after polling has finished. If there is a proxy configured, it can happen that the proxy does not return actual changes but a cached state.
 
 * *Sync* +
-Syncing is defined as the task where any changes will be synchronized, no matter if they occurred in the Desktop app or on the server side. If syncing is enforced, it does not depend on former polling.
+Syncing is defined as the task where any changes will be synchronized, no matter if they occurred in the Desktop app or on the server side. Syncing does not depend on former polling while polling can result in a sync.
 
 * *Local Discovery* +
 Local discovery is defined as the task where the Desktop app looks for changes on the local filesystem. A local discovery can internally be enforced to check for changes that have been missed for example when the Desktop app was shut down during ongoing changes on the local filesystem. Any changes identified on the local filesystem trigger a sync after local discovery has finished.

--- a/modules/ROOT/pages/faq.adoc
+++ b/modules/ROOT/pages/faq.adoc
@@ -15,7 +15,7 @@
 Polling is defined as the task where the Desktop app queries the server for changes. If the server responds with a change that had happened on the backend, the client will start syncing the changes after polling has finished. If there is a proxy configured, it can happen that the proxy does not return actual changes but a cached state.
 
 * *Syncing* +
-Syncing is defined as the task where any changes will be synchronized, no matter if they occurred in the Desktop app or on the service side. If syncing is enforced, it does not depend on former polling.
+Syncing is defined as the task where any changes will be synchronized, no matter if they occurred in the Desktop app or on the server side. If syncing is enforced, it does not depend on former polling.
 
 * *Local Discovery* +
 Local discovery is defined as the task where the Desktop app looks for changes on the local filesystem. A local discovery can internally be enforced to check for changes that have been missed for example when the Desktop app was shut down during ongoing changes on the local filesystem. Any changes identified on the local filesystem trigger a sync after local discovery has finished.


### PR DESCRIPTION
Fixes: #266 (Document the desktop clients query intervals and the impacts)

The terms used were not clear and the text needed improvement for better understanding.

The split of the content and the explanation was based on a discussion with @fmoc (many thanks for the input)

Language review welcomed 😄 

Backport to 4.0 and 4.1