### PR TITLE
Intermediary upgrade step from 2.5 to 5.0 via 4.0

### DIFF
--- a/modules/ROOT/pages/automatic_updater.adoc
+++ b/modules/ROOT/pages/automatic_updater.adoc
@@ -6,7 +6,7 @@
 
 {description} The Automatic Updater updates only on Mac OS X and Windows computers; Linux users only need to use their normal package managers. However, on Linux systems the Updater will check for updates and notify you when a new version is available.
 
-IMPORTANT: When planning to upgrade from a Desktop app release =< 2.5 to a release >=5.0 you must make an intermediary step to release 4.0 before doing the final upgrade.
+IMPORTANT: When planning to upgrade from a Desktop app release <= 2.5 to a release >=5.0 you must make an intermediary step to release 4.0 before doing the final upgrade.
 
 == Basic Workflow
 

--- a/modules/ROOT/pages/automatic_updater.adoc
+++ b/modules/ROOT/pages/automatic_updater.adoc
@@ -6,6 +6,8 @@
 
 {description} The Automatic Updater updates only on Mac OS X and Windows computers; Linux users only need to use their normal package managers. However, on Linux systems the Updater will check for updates and notify you when a new version is available.
 
+IMPORTANT: When planning to upgrade from a Desktop app release =< 2.5 to a release >=5.0 you must make an intermediary step to release 4.0 before doing the final upgrade.
+
 == Basic Workflow
 
 The following sections describe how to use the Automatic Updater on different operating systems.


### PR DESCRIPTION
Fixes: #406 (Migration from before 2.5 -> 5 needs an intermediate installation of 4.0 (for 5.0))

Add a note in the automatic upgrade guide to take an intermediary step.

No backport.