### PR TITLE
[CI] Do not try to cancel previous running builds

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -77,7 +77,7 @@ def build(ctx, environment, latest_version, deployment_branch, base_branch, pdf_
                 "pull": "always",
                 "image": "plugins/s3-cache:1",
                 "settings": {
-                    "endpoint": from_secret("cache_s3_endpoint"),
+                    "endpoint": from_secret("cache_s3_server"),
                     "access_key": from_secret("cache_s3_access_key"),
                     "secret_key": from_secret("cache_s3_secret_key"),
                     "restore": "true",
@@ -120,7 +120,7 @@ def build(ctx, environment, latest_version, deployment_branch, base_branch, pdf_
                 "pull": "always",
                 "image": "plugins/s3-cache:1",
                 "settings": {
-                    "endpoint": from_secret("cache_s3_endpoint"),
+                    "endpoint": from_secret("cache_s3_server"),
                     "access_key": from_secret("cache_s3_access_key"),
                     "secret_key": from_secret("cache_s3_secret_key"),
                     "rebuild": "true",
@@ -144,7 +144,7 @@ def build(ctx, environment, latest_version, deployment_branch, base_branch, pdf_
                 "pull": "always",
                 "image": "plugins/s3-cache:1",
                 "settings": {
-                    "endpoint": from_secret("cache_s3_endpoint"),
+                    "endpoint": from_secret("cache_s3_server"),
                     "access_key": from_secret("cache_s3_access_key"),
                     "secret_key": from_secret("cache_s3_secret_key"),
                     "flush": "true",
@@ -185,7 +185,7 @@ def build(ctx, environment, latest_version, deployment_branch, base_branch, pdf_
                 "pull": "if-not-exists",
                 "image": "plugins/slack",
                 "settings": {
-                    "webhook": from_secret("slack_webhook_private"),
+                    "webhook": from_secret("rocketchat_talk_webhook"),
                     "channel": "documentation",
                 },
                 "when": {

--- a/.drone.star
+++ b/.drone.star
@@ -19,7 +19,7 @@ def main(ctx):
     deployment_branch = default_branch
     pdf_branch = default_branch
 
-    return cancelPreviousBuilds() + [
+    return [
         checkStarlark(),
         build(ctx, environment, latest_version, deployment_branch, base_branch, pdf_branch),
         trigger(ctx, environment, latest_version, deployment_branch, base_branch, pdf_branch),
@@ -256,27 +256,3 @@ def from_secret(name):
     return {
         "from_secret": name,
     }
-
-def cancelPreviousBuilds():
-    return [{
-        "kind": "pipeline",
-        "type": "docker",
-        "name": "cancel-previous-builds",
-        "clone": {
-            "disable": True,
-        },
-        "steps": [{
-            "name": "cancel-previous-builds",
-            "image": "owncloudci/drone-cancel-previous-builds",
-            "settings": {
-                "DRONE_TOKEN": {
-                    "from_secret": "drone_token",
-                },
-            },
-        }],
-        "trigger": {
-            "ref": [
-                "refs/pull/**",
-            ],
-        },
-    }]


### PR DESCRIPTION
The drone token is no longer available to PRs, so we cannot find other builds that are in progress and cancel them.
Drop this "feature".

And adjust the drone env variables for the new names.