### PR TITLE
Add Apple ARM64 to System Requirements

### DIFF
--- a/modules/ROOT/pages/installing.adoc
+++ b/modules/ROOT/pages/installing.adoc
@@ -48,8 +48,7 @@ Windows::
 
 macOS::
 * macOS 10.13+
-** x86-64 or Apple M in Rosetta 2 emulation
-** M1 native support planned for Q2 2023 - no issues in regard to performance or otherwise known at this time!
+** x86-64 or ARM64 (Apple Silicon)
 
 Linux::
 * Debian 11 & 12 (x86-64)


### PR DESCRIPTION
No longer tech preview in 4.1+

Backport to master and 4.2