### PR TITLE
Changes necessary for 4.2

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -6,7 +6,7 @@ def main(ctx):
     # Version shown as latest in generated documentations
     # It's fine that this is out of date in version branches, usually just needs
     # adjustment in master/deployment_branch when a new version is added to site.yml
-    latest_version = "4.1"
+    latest_version = "4.2"
     default_branch = "master"
 
     # Current version branch (used to determine when changes are supposed to be pushed)

--- a/site.yml
+++ b/site.yml
@@ -31,8 +31,8 @@ asciidoc:
     # Antora pagination (prev page, next page)
     page-pagination: true
 #   desktop
-    latest-desktop-version: '4.1'
-    previous-desktop-version: '4.0'
+    latest-desktop-version: '4.2'
+    previous-desktop-version: '4.1'
   extensions:
     - ./lib/extensions/tabs.js
     - ./lib/extensions/remote-include-processor.js


### PR DESCRIPTION
These are the changes necessary to finalize the creation of the 4.2 branch.

The 4.2 branch is already pushed and prepared and is included in the branch protection rules.

When 4.2 (Desktop) is finally out, the 4.0 branch can be archived, see step 4 in https://github.com/owncloud/docs-client-desktop/blob/master/docs/new-version-branch.md

Note, that the 4.2 branch in this repo is already created, but the `latest` pointer on the web will be set to it automatically when the tag in Desktop is set. This means, that in the docs homepage, `latest` will point to 4.1 until the tag in Desktop is set accordingly. When merging this PR, 4.0 will be dropped from the web but is available via pdf as usual.

Note, this PR must be merged before the 4.2 tag in Desktop is set to avoid a 404 for `latest`.

Note that a PR in docs must be made to announce the 4.2 branch. The docs PR must be merged AFTER this PR is merged to avoid a CI error in docs.

Before merging this PR, we should take care that 4.0 has all changes necessary merged as post
merging the 4.0 pdf is fixed.

@michaelstingl @HanaGemela @fmoc fyi

@mmattel @EParzefall @phil-davis
Post merging this, we need to backport all relevant changes to 4.2
