### PR TITLE
Adapt Office Web Apps page

### DIFF
--- a/modules/ROOT/pages/web_app.adoc
+++ b/modules/ROOT/pages/web_app.adoc
@@ -18,7 +18,7 @@ When more than one person is working on the same document and using a locally in
 
 == Open Files via Office Web Apps
 
-The first image shows an office file via the browser, based on Infinite Scale as backend.
+The first image shows an office file via the browser, based on the Infinite Scale backend.
 
 image::web_app/office_file_in_browser.png[file in browser, width=600,pdfwidth=70%]
 

--- a/modules/ROOT/pages/web_app.adoc
+++ b/modules/ROOT/pages/web_app.adoc
@@ -1,24 +1,24 @@
 = Open Files with Office Web Apps
 :toc: right
-:description: When using Infinite Scale, you can open and edit synced office files locally using office web apps.
+:description: You can open and edit synced files locally using web apps without the need of local app installations.
 
 == Introduction
 
 {description} This is very beneficial if:
 
-*  your local environment does not have an office package installed or available,
+* your local environment does not have an office package installed or available,
 * you are collaborating with others on the same document.
 
-When more than one person is working on the same document and using a locally installed office application, synchronization conflicts may happen if others sync a changed document while someone else is editing it. This can be hard to resolve. When using office web apps, collaborative working is managed by the web application and synchronization is no longer an issue.
+When more than one person is working on the same document and using a locally installed application like office, synchronization conflicts may happen if others sync a changed document while someone else is editing it. This can be hard to resolve. When using web apps, collaborative working is managed by the web application and synchronization is no longer an issue.
 
 == Prerequisite
 
-* The user only needs a browser. No settings need to be made in the Desktop App.
-* The Infinite Scale instance in the backend needs to have been configured accordingly with office web apps enabled. The administrator can configure the system for multiple or only particular office file types. If office web apps are not configured and enabled for all available or particular office file types, the functionality is either not available in the context menu at all or only for the configured ones. Contact your administrator for more details.
+* The user only needs to have a browser installed. No settings need to be made in the Desktop App.
+* The the backend, which is either Infinite Scale or ownCloud Server needs to have been configured accordingly with web apps enabled. The administrator can configure the system for multiple or only particular office file types if available. If web apps are not configured and enabled for all available or particular file types, the functionality is either not available in the context menu at all or only for the configured ones. Contact your administrator for more details.
 
 == Open Files via Office Web Apps
 
-The first image shows an office file via the browser.
+The first image shows an office file via the browser, based on Infinite Scale as backend.
 
 image::web_app/office_file_in_browser.png[file in browser, width=600,pdfwidth=70%]
 
@@ -26,12 +26,12 @@ This file gets synced by the Desktop App and is locally available.
 
 image::web_app/office_file_in_explorer.png[file in explorer, width=600,pdfwidth=70%]
 
-btn:[Right-click] on the file to open the context menu and click menu:ownCloud[open in ...] to select the application available. Note that the web app shown is the one configured by the admin for this office file type. If menu:open in ...[] is not available, office web apps have either not been enabled by the administrator at all or not for this office file type.
+btn:[Right-click] on the file to open the context menu and click menu:ownCloud[Open in ...] to select the application available. Note that the web app shown is the one configured by the admin for this file type. If menu:Open in ...[] is not available, web apps have either not been enabled by the administrator at all or not for this file type.
 
 image::web_app/office_file_context_menu.png[file context menu, width=600,pdfwidth=70%]
 
-A browser window with the web app selected opens the file. When you are leaving the office web app, changed files are saved automatically.
+A browser window with the web app selected opens the file. When you are leaving the web app, changed files are saved automatically.
 
 image::web_app/office_file_in_web_app.png[file in web app, width=550,pdfwidth=70%]
 
-Note that if multiple persons are accessing the same file via the office web app, the app can show who has opened the file. Depending on the office web app, final saving may occur when the last person accessing a file in the office web app closes the office web app session or the last tab. This is indicated by the changed modification time. Syncing back will only occur after the file has been saved.
+Note that if multiple persons are accessing the same file via the web app, the app may show who has opened the file. Depending on the web app, final saving may occur when the last person accessing a file in the web app closes the web app session or the last tab. This is indicated by the changed modification time. Syncing back will only occur after the file has been saved.


### PR DESCRIPTION
References: https://github.com/owncloud/docs-server/issues/1043 (Document core: App Registry)

With oC Server 10.13 that introduced an app registry, web apps in the desktop are now available by both products. This PR "neutralizes" the text to be independed of the backend used.

Note that oC Server has not only office apps but also drawio, therefore neutralizing to web apps where possible.

Note that the referenced issue is not fixed by merging this PR as it needs more PR's covering different manuals.

Backport to 4.1 and 4.2