### PR TITLE
[5.0] [PR 525] Bump @asciidoctor/core from 2.2.6 to 3.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "dependencies": {
     "@antora/cli": "^2.3",
     "@antora/site-generator-default": "^2.3",
-    "@asciidoctor/core": "^2.2.6",
+    "@asciidoctor/core": "^3.0.2",
     "@elastic/elasticsearch": "^7.17.13",
     "asciidoctor-kroki": "^0.17.0",
     "cheerio": "^1.0.0-rc.12",

--- a/yarn.lock
+++ b/yarn.lock
@@ -146,13 +146,21 @@
     vinyl "~2.2"
     vinyl-fs "~3.0"
 
-"@asciidoctor/core@^2.2.6":
-  version "2.2.6"
-  resolved "https://registry.yarnpkg.com/@asciidoctor/core/-/core-2.2.6.tgz#a59a9e8ab48ac0a615d5a3200214d3071291c5d5"
-  integrity sha512-TmB2K5UfpDpSbCNBBntXzKHcAk2EA3/P68jmWvmJvglVUdkO9V6kTAuXVe12+h6C4GK0ndwuCrHHtEVcL5t6pQ==
+"@asciidoctor/core@^3.0.2":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@asciidoctor/core/-/core-3.0.2.tgz#05df6c8f6c8a975e1ecf1ac886e826af69c49d94"
+  integrity sha512-GbQWpqLlM/kN+90QrlLYISdU/vbGkUSeHsBQR9BzYNmVHDd6CEb/xfQZIFUo//EtT7e+QS3Sv3yYDzgjr96TbA==
   dependencies:
-    asciidoctor-opal-runtime "0.3.3"
-    unxhr "1.0.1"
+    "@asciidoctor/opal-runtime" "3.0.1"
+    unxhr "1.2.0"
+
+"@asciidoctor/opal-runtime@3.0.1":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@asciidoctor/opal-runtime/-/opal-runtime-3.0.1.tgz#b6d995fb36bdb27cc7350de39cece9dd302fce40"
+  integrity sha512-iW7ACahOG0zZft4A/4CqDcc7JX+fWRNjV5tFAVkNCzwZD+EnFolPaUOPYt8jzadc0+Bgd80cQTtRMQnaaV1kkg==
+  dependencies:
+    glob "8.1.0"
+    unxhr "1.2.0"
 
 "@elastic/elasticsearch@^7.17.13":
   version "7.17.13"
@@ -242,14 +250,6 @@ asciidoctor-kroki@^0.17.0:
     pako "2.1.0"
     rusha "0.8.14"
     unxhr "1.2.0"
-
-asciidoctor-opal-runtime@0.3.3:
-  version "0.3.3"
-  resolved "https://registry.yarnpkg.com/asciidoctor-opal-runtime/-/asciidoctor-opal-runtime-0.3.3.tgz#2667635f858d3eb3fdfcf6795cf68138e2040174"
-  integrity sha512-/CEVNiOia8E5BMO9FLooo+Kv18K4+4JBFRJp8vUy/N5dMRAg+fRNV4HA+o6aoSC79jVU/aT5XvUpxSxSsTS8FQ==
-  dependencies:
-    glob "7.1.3"
-    unxhr "1.0.1"
 
 asciidoctor.js@1.5.9:
   version "1.5.9"
@@ -346,6 +346,13 @@ brace-expansion@^1.1.7:
   dependencies:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
+
+brace-expansion@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-2.0.1.tgz#1edc459e0f0c548486ecf9fc99f2221364b9a0ae"
+  integrity sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==
+  dependencies:
+    balanced-match "^1.0.0"
 
 braces@~3.0:
   version "3.0.2"
@@ -990,17 +997,16 @@ glob@6.0.4:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@7.1.3:
-  version "7.1.3"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.3.tgz#3960832d3f1574108342dafd3a67b332c0969df1"
-  integrity sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==
+glob@8.1.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-8.1.0.tgz#d388f656593ef708ee3e34640fdfb99a9fd1c33e"
+  integrity sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==
   dependencies:
     fs.realpath "^1.0.0"
     inflight "^1.0.4"
     inherits "2"
-    minimatch "^3.0.4"
+    minimatch "^5.0.1"
     once "^1.3.0"
-    path-is-absolute "^1.0.0"
 
 glob@^7.1.1:
   version "7.1.7"
@@ -1498,6 +1504,13 @@ minimatch-all@~1.1:
   integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
   dependencies:
     brace-expansion "^1.1.7"
+
+minimatch@^5.0.1:
+  version "5.1.6"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-5.1.6.tgz#1cfcb8cf5522ea69952cd2af95ae09477f122a96"
+  integrity sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==
+  dependencies:
+    brace-expansion "^2.0.1"
 
 minimist@^1.1.0, minimist@^1.2.5, minimist@^1.2.6:
   version "1.2.6"
@@ -2226,11 +2239,6 @@ universalify@^0.1.0:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.2.tgz#b646f69be3942dabcecc9d6639c80dc105efaa66"
   integrity sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==
-
-unxhr@1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/unxhr/-/unxhr-1.0.1.tgz#92200322d66c728993de771f9e01eeb21f41bc7b"
-  integrity sha512-MAhukhVHyaLGDjyDYhy8gVjWJyhTECCdNsLwlMoGFoNJ3o79fpQhtQuzmAE4IxCMDwraF4cW8ZjpAV0m9CRQbg==
 
 unxhr@1.2.0:
   version "1.2.0"


### PR DESCRIPTION
Backport of PR #525

Necessary for local builds only.