### PR TITLE
[5.2] [PR 598] Fix command typo in generate-index.js

### DIFF
--- a/ext-antora/generate-index.js
+++ b/ext-antora/generate-index.js
@@ -155,7 +155,7 @@ function indexDelete(client) {
         resolve(resp)
       })
       .catch((err) => {
-        console.warning(err)
+        console.warn(err)
         resolve(true)
       })
   })


### PR DESCRIPTION
Backport of #598