### PR TITLE
Remove remaining hardcoded links to branding

### DIFF
--- a/modules/ROOT/pages/automatic_updater.adoc
+++ b/modules/ROOT/pages/automatic_updater.adoc
@@ -85,7 +85,7 @@ HKEY_LOCAL_MACHINE\Software\Policies\ownCloud\ownCloud
 .  Add the key `skipUpdateCheck` (of type DWORD).
 .  Specify a value of `1` to the machine.
 
-NOTE: Enterprise branded Desktop Apps (https://doc.owncloud.com/branded_clients/[Building Branded ownCloud Clients]) have different key names, which are set in ownBrander using the Application Vendor and Application Name fields.
+NOTE: Enterprise branded Desktop Apps have different key names, which are set during the branding process using the Application Vendor and Application Name fields.
 
 Your key names look like this:
 


### PR DESCRIPTION
References: https://github.com/owncloud/docs-server/pull/1440 (Remove remaining hardcoded links to branding)

This PR removes remaining hardcoded links to branding. These links were made as html links and not as xref thats why the got missed in the first run.

Backport to 5.2 and 5.3