### PR TITLE
Fixing an italic formatting issue

### DIFF
--- a/modules/ROOT/pages/installing.adoc
+++ b/modules/ROOT/pages/installing.adoc
@@ -64,7 +64,7 @@ endif::[]
 == Download
 
 ifeval::["{targetbuild}" == "oc"]
-You can download the latest version of the Desktop App from the {client-download-url}[Desktop App Download, window=_blank] page. There are Desktop Apps for _Linux_, _macOS_, and _Microsoft Windows_ available.
+You can download the latest version of the Desktop App from the {client-download-url}[Desktop App Download, window=_blank] page. There are Desktop Apps for __Microsoft Windows, macOS__ and __Linux__ available.
 endif::[]
 
 ifeval::["{targetbuild}" == "kw"]


### PR DESCRIPTION
This PR fixes an issue formatting some text to italic that contains a comma which needs special treatment according to the Antora docs. I have overseen this when creating the docs as this results in an underline printed that is hard to see. Now, the text is renderd italic properly.

Backport to 6.0 