### PR TITLE
Add page aliases for two removed pages

### DIFF
--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -1,7 +1,8 @@
 = Introduction to the Desktop App
 :toc: right
 :toclevels: 2
-:description: This is the description of the Desktop App which allows you to synchronize your files from connected servers to your local computer. 
+:description: This is the description of the Desktop App which allows you to synchronize your files from connected servers to your local computer.
+:page-aliases: advanced_usage/command_line_client.adoc, advanced_usage/command_line_parameters.adoc
 
 include::partial$conditional_naming.adoc[]
 


### PR DESCRIPTION
References: #674 (fix: remove command line client)

Adding page aliases to satisfy google search.