### PR TITLE
fix: update oc_client-version to 7.1.0

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -20,4 +20,4 @@ asciidoc:
     #
     # this is the version string that is used for kw or oc to reference the binary
     kw_client-version: 2.0.0
-    oc_client-version: 6.0.0
+    oc_client-version: 7.1.0


### PR DESCRIPTION
## Context

The `master` branch publishes the Desktop App docs as the rolling `next` (prerelease) version, which tracks the upcoming **7.1** client release. However the binary version string driving the rendered download filenames was still hardcoded to `6.0.0`, producing wrong install commands for users (e.g. `ownCloud-6.0.0.x64.msi`).

## Change

A single line in `antora.yml`:

```diff
-    oc_client-version: 6.0.0
+    oc_client-version: 7.1.0
```

The docs use attribute-driven versioning: this one canonical attribute flows through `conditional_naming.adoc` (`:client-version: {oc_client-version}`) into every download command and AppImage filename across `installing.adoc` and `troubleshooting.adoc`. No per-page edits are required.

## Deliberately unchanged

- `version: 'next'` — master stays the rolling prerelease per `docs/the-branching-workflow.md`.
- `index.adoc` compatibility note ("version 7.0 … use version 6.x instead") — intentional; 6.x is the last ownCloud Server-compatible line.
- Stale numbers inside non-rendering AsciiDoc comments (`installing.adoc`, `using.adoc`).

## Verification

Built locally with Antora (Node 22, matching CI):

- ✅ Clean build, no errors.
- ✅ Rendered output now shows `ownCloud-7.1.0.x64.msi` and `ownCloud-7.1.0-x86_64.AppImage`.
- ✅ No stray `6.0.0` remains in rendered desktop pages.
- ✅ `index.adoc` compatibility note renders unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)