### PR TITLE
ci: enable building the 7.1 version branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - '7.1'
       - '6.0'
       - '5.3'
     tags:


### PR DESCRIPTION
These are the changes necessary to finalize the creation of the 7.1 branch.

* The 7.1 branch is already pushed and prepared (`version: '7.1'`, prerelease flag removed,
  added to CI push triggers).

* This PR wires `master`'s CI to also build the `7.1` branch, so changes backported from
  master to 7.1 are built.

* Note that this PR can be merged at any time but:
  * must be merged **before** applying content changes and
  * **before** merging the docs PR to include this version (owncloud/docs#5107).

* Post merging this, we need to backport all relevant changes created in master to 7.1.

> Note: the process doc references `.drone.star`, but this repo now uses GitHub Actions —
> the branch-build list lives in `.github/workflows/ci.yml` under `on.push.branches`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
