### PR TITLE
docs: fix typos, doubled words, and grammar across pages

### DIFF
--- a/modules/ROOT/pages/automatic_updater.adoc
+++ b/modules/ROOT/pages/automatic_updater.adoc
@@ -6,7 +6,7 @@ include::partial$conditional_naming.adoc[]
 
 == Introduction
 
-{description} The Automatic Updater only works on Windows computers. macOS Linux users must use the same process they used to install the Desktop App. However, the updater will check for updates and notify you when a new version is available.
+{description} The Automatic Updater only works on Windows computers. macOS and Linux users must use the same process they used to install the Desktop App. However, the updater will check for updates and notify you when a new version is available.
 
 == Basic Workflow
 

--- a/modules/ROOT/pages/conflicts.adoc
+++ b/modules/ROOT/pages/conflicts.adoc
@@ -1,6 +1,6 @@
 = Manage Synchronisation Conflicts
 :toc: right
-:description: The Desktop App uploads local changes and downloads remote changes. If a file has changed locally *and* remotely between sync runs, the Desktop app will not be able to resolve the situation on its own.
+:description: The Desktop App uploads local changes and downloads remote changes. If a file has changed locally *and* remotely between sync runs, the Desktop App will not be able to resolve the situation on its own.
 
 include::partial$conditional_naming.adoc[]
 

--- a/modules/ROOT/pages/faq.adoc
+++ b/modules/ROOT/pages/faq.adoc
@@ -67,7 +67,7 @@ It is possible for another program to change the modification date/time (mtime) 
 
 Examples of other programs changing the mtime are backup tools or in rare cases the Windows indexing service. The Desktop App cannot do anything about this.
 
-If you have files with an `.eml` extension (Windows Mail, Windows Live Mail), the Microsoft indexer automatically and continuously changes the mtime of the files. To solve this problem, you can:
+If you have files with an `.eml` extension (Windows Mail, Windows Live Mail), the Microsoft indexer automatically and continuously changes their modification times. To solve this problem, you can:
 
 * Remove the extension from the indexer (menu:Indexing Options[Advanced > File Types])
 * Uninstall Windows Mail, Windows Live Mail. Note that when reinstalling, the issue reappears again. See {wordpress1-url}[Windows indexer changes modification dates of .eml files] for more information.

--- a/modules/ROOT/pages/filenames.adoc
+++ b/modules/ROOT/pages/filenames.adoc
@@ -10,7 +10,7 @@ include::partial$conditional_naming.adoc[]
 
 == Introduction
 
-{description} Creating files and folders with allowed names or maximum lengths on one OS, may have issues or even can´t be synced because of different rules in another OS. This page gives you a brief overview of limitations regarding file and folder names on different operating systems.
+{description} Creating files and folders with allowed names or maximum lengths on one OS, may have issues or even can't be synced because of different rules in another OS. This page gives you a brief overview of limitations regarding file and folder names on different operating systems.
 
 [NOTE]
 ====
@@ -33,7 +33,7 @@ endif::[]
 
 == Examples and Pitfalls
 
-The following examples are put on top of this document to highlight file naming issues that can be avoided easily. 
+The following examples illustrate file naming issues that can be easily avoided.
 
 ifeval::["{targetbuild}" == "oc"]
 . If you create a file in Linux or macOS like `my-filename.` (see the dot at the end) or `my-filename.LPT1` (see the reserved name LPT1), you can sync the file with your Desktop App if the mount target is on Linux. If a Windows user tries to synchronize these files, Windows will reject the file. Comparing the file list in both environments shows that one side has more files than the other. There will be *no notification* as this is an OS dependency. 
@@ -56,7 +56,7 @@ Example source file names on macOS that will fail to sync to Windows:
 --
 endif::[]
 
-. If you rename an existing file in Linux or macOS by just changing the case like `{bin_name}` -> `{ini_name}`, it is very likely to get problems on the Windows side because the file looks (and is) the same for Windows.
+. If you rename an existing file in Linux or macOS by just changing the case like `{bin_name}` -> `{ini_name}`, it is very likely to cause problems on the Windows side because the file looks (and is) the same for Windows.
 
 == Maximum Path Length Limitation
 
@@ -111,4 +111,4 @@ Windows::
 Filenames must not end with a space or a dot.
 
 Linux or macOS::
-When the Desktop App is on Linux or macOS and the server you sync to is on Windows, you cannot have the same file or folder name but with different casings. A cross icon will appear, indicating that indicates that the file can't be synced. Files on Linux or macOS must match with the Windows rules for a successful sync.
+When the Desktop App is on Linux or macOS and the server you sync to is on Windows, you cannot have the same file or folder name but with different casings. A cross icon will appear, indicating that the file can't be synced. Files on Linux or macOS must match with the Windows rules for a successful sync.

--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -10,7 +10,7 @@ include::partial$conditional_naming.adoc[]
 
 {description} The app is available for *Windows*, *macOS*, and various *Linux* distributions.
 
-== Compatiblility
+== Compatibility
 
 NOTE: Starting with {ini_name} version 7.0, the Desktop App will no longer support ownCloud Server, only ownCloud Infinite Scale. To use the Desktop App with ownCloud Server, use version 6.x instead.
 

--- a/modules/ROOT/pages/installing.adoc
+++ b/modules/ROOT/pages/installing.adoc
@@ -95,7 +95,7 @@ image:installing/kw-windows-install-setup-custom.png[Custom Setup,width=100]
 image:installing/kw-windows-install-setup-ready.png[Start Install,width=100]
 image:installing/kw-windows-installing-uac.png[UAC,width=100]
 image:installing/kw-windows-install-finished.png[Install Finished,width=100]
-image:installing/kw-windows-startmenu-entry.png[Start Menue,width=100]
+image:installing/kw-windows-startmenu-entry.png[Start Menu,width=100]
 --
 endif::[]
 
@@ -108,7 +108,7 @@ image:installing/oc-windows-install-setup-custom.png[Custom Setup,width=100]
 image:installing/oc-windows-install-setup-ready.png[Start Install,width=100]
 // image:installing/oc-windows-installing-uac.png[UAC,width=100]
 image:installing/oc-windows-install-finished.png[Install Finished,width=100]
-image:installing/oc-windows-startmenu-entry.png[Start Menue,width=100]
+image:installing/oc-windows-startmenu-entry.png[Start Menu,width=100]
 --
 endif::[]
 
@@ -302,7 +302,7 @@ a| image:installing/advanced_settings.png[Advanced Settings,width=150]
 |===
 --
 
-* Now, the the `Desktop.ini` file is visible, add a setting to make an icon change persistent. To do this, open it with an editor.
+* Now, the `Desktop.ini` file is visible, add a setting to make an icon change persistent. To do this, open it with an editor.
 ** The current content may look like this:
 +
 --

--- a/modules/ROOT/pages/removing.adoc
+++ b/modules/ROOT/pages/removing.adoc
@@ -10,7 +10,7 @@ include::partial$conditional_naming.adoc[]
 
 == Removing the Binary
 
-* For all opperating systems (OS): +
+* For all operating systems (OS): +
 Follow your operating system's instructions for removing the Desktop App binary.
 
 * In Linux, when using an AppImage: +

--- a/modules/ROOT/pages/troubleshooting.adoc
+++ b/modules/ROOT/pages/troubleshooting.adoc
@@ -15,7 +15,7 @@ This documentation focuses on issues that require additional support, not on beh
  
 The following two general issues can result in failed synchronization:
 
-* The instance setup you synchroinize with is incorrect.
+* The instance setup you synchronize with is incorrect.
 * The Desktop App contains a bug.
 
 == Identifying Basic Functionality Problems
@@ -111,7 +111,7 @@ endif::[]
 . Later, to find the log files, click the btn:[Open folder] button.
 . Select the logs for the time frame in which the issue occurred.
 
-NOTE: The choice to enable logging is retained across restarts of the Desktop App restarts.
+NOTE: The choice to enable logging is retained across restarts of the Desktop App.
 
 ==== Log HTTP Requests and Responses
 
@@ -173,10 +173,10 @@ The verbosity of the generated log files increases.
 +
 --
 ifeval::["{targetbuild}" == "oc"]
-image:troubleshooting/oc-windows-log-files-to-keep.png[CLog files to keep,width=250]
+image:troubleshooting/oc-windows-log-files-to-keep.png[Log files to keep,width=250]
 endif::[]
 ifeval::["{targetbuild}" == "kw"]
-image:troubleshooting/kw-windows-log-files-to-keep.png[CLog files to keep,width=250]
+image:troubleshooting/kw-windows-log-files-to-keep.png[Log files to keep,width=250]
 endif::[]
 --
 

--- a/modules/ROOT/pages/using.adoc
+++ b/modules/ROOT/pages/using.adoc
@@ -155,13 +155,13 @@ Overlay icons are similar to the xref:systray-icons[Systray Icons]. Their behavi
 
 * The overlay icon of an individual file indicates its current sync state.
 
-** image:using/fmoi_ok.png[OK Synbol, width=18] If the file is in sync with the server version, it displays the green checkmark icon.
+** image:using/fmoi_ok.png[OK Symbol, width=18] If the file is in sync with the server version, it displays the green checkmark icon.
 
-** image:using/fmoi_sync.png[Sync Synbol, width=18] If the file is waiting to sync or is currently syncing, it displays the blue cycling icon.
+** image:using/fmoi_sync.png[Sync Symbol, width=18] If the file is waiting to sync or is currently syncing, it displays the blue cycling icon.
 
-** image:using/fmoi_warn.png[Warn Synbol, width=18] If the file is ignored during sync, for example because it is on your exclude list or because it is a symbolic link, it displays the yellow warning icon.
+** image:using/fmoi_warn.png[Warn Symbol, width=18] If the file is ignored during sync, for example because it is on your exclude list or because it is a symbolic link, it displays the yellow warning icon.
 
-** image:using/fmoi_error.png[Error Synbol, width=18] If there is a sync error or the file is blacklisted, it displays the red X icon.
+** image:using/fmoi_error.png[Error Symbol, width=18] If there is a sync error or the file is blacklisted, it displays the red X icon.
 endif::[]
 
 ifeval::["{targetbuild}" == "kw"]
@@ -331,7 +331,7 @@ To make a folder available for synchronization on {ini_name}, you must first set
 ====
 Changing the synchronization property is:
 
-* Only availabe on folders located in the {ini_name} root.
+* Only available on folders located in the {ini_name} root.
 * Not available in subfolders.
 * Not available for individual files.
 ====
@@ -384,7 +384,7 @@ Opens {ini_name} via the browser.
 If you need to synchronize data immediately, such as when you are traveling and need to continue working offline, you can force a folder to sync before you go offline.
 
 ** menu:Pause sync[] / menu:Restart sync[] +
-Pauses or restarts a paused sync operations.
+Pauses or restarts a paused sync operation.
 
 ** menu:Remove folder sync connection[] +
 See the section xref:remove-sync-relationships[Remove Sync Relationships] below for details.
@@ -416,7 +416,7 @@ Spaces in Infinite Scale are similar to folders:
 
 === Managing Resources to Synchronize
 
-When an account gets added the first time, you can select which remote resources you want to synchronize. This includes the syncronization type which defaults to VFS if available on your operating system (OS) or selective sync where you manually select the resoures to be synchronized otherwise. These resources are represented by the Desktop app as local folders using the base path defined during account setup.
+When an account gets added the first time, you can select which remote resources you want to synchronize. This includes the synchronization type which defaults to VFS if available on your operating system (OS) or selective sync where you manually select the resources to be synchronized otherwise. These resources are represented by the Desktop app as local folders using the base path defined during account setup.
 
 If VFS is available for your OS but selective sync has been chosen, you can at any time switch to VFS and vice versa. Note to check the available disk space before switching from VFS to selective sync (Disable Virtual File support). 
 
@@ -576,11 +576,11 @@ You may have some local files or directories that you do not want to backup and 
 Note that rules for ignored files are also applied to folders.
 
 ifeval::["{targetbuild}" == "oc"]
-image::using/oc-windows-ignored-files-editor.png[Ingnored Files Editor,width=100]
+image::using/oc-windows-ignored-files-editor.png[Ignored Files Editor,width=100]
 endif::[]
 
 ifeval::["{targetbuild}" == "kw"]
-image::using/kw-windows-ignored-files-editor.png[Ingnored Files Editor,width=100]
+image::using/kw-windows-ignored-files-editor.png[Ignored Files Editor,width=100]
 endif::[]
 ====
 

--- a/modules/ROOT/pages/vfs.adoc
+++ b/modules/ROOT/pages/vfs.adoc
@@ -49,9 +49,9 @@ The file is implicitly _hydrated_ and could be _dehydrated_ by the system if spa
 An empty representation of the file and is only available if the sync service is available.
 
 * *Syncing file:* +
-The file is planned for or currently in the process of synchrinozation..
+The file is planned for or currently in the process of synchronization.
 
-The following picture shows how the file statuses: _full pinned_, _full_, _placeholder_ and _syncing_ are displayed in File Explorer:
+The following picture shows how the file statuses (_full pinned_, _full_, _placeholder_, and _syncing_) are displayed in File Explorer:
 
 image:vfs/vfs-ms-cloud-file-states-file-explorer.png[File States]
 --
@@ -76,7 +76,7 @@ Similar to OneDrive, since it also uses Microsoft's virtual file system, there a
 
 == Desktop App's VFS Implementation
 
-Note that when using Windows and VFS, the Desktop App *must* have full control over the sync folder and its subfolders where the data is stored. If this is not the case, you will most likely get access denied errors when syncing VFS data. For more details, see the xref:troubleshooting.adoc#error-updating-metadata-access-denied[Troubleshooting] guide for more details.
+Note that when using Windows and VFS, the Desktop App *must* have full control over the sync folder and its subfolders where the data is stored. If this is not the case, you will most likely get access denied errors when syncing VFS data. For more details, see the xref:troubleshooting.adoc#error-updating-metadata-access-denied[Troubleshooting] guide.
 
 === Manage VFS from Windows Explorer
 
@@ -86,7 +86,7 @@ You can manage *individual* files or *entire folders* in the Explorer window by 
 
 To save space on the local file system, synchronized files are placeholders until you open them or manually select them to have a local copy. To create a local copy of a placeholder file manually, see the following procedure:
  
-. Select the folder containing the file that is a _Placehholder_ of which you want to have a local copy.
+. Select the folder containing the file that is a _Placeholder_ of which you want to have a local copy.
 . Select the context menu for the file by doing a btn:[right click].
 . To create a _Full Pinned_ file (have a local copy of it), use the action btn:[Always keep on this device].
 . The state of the file will change to synchronizing, the icon in the btn:[Status] column changes to _Synchronizing_.
@@ -115,8 +115,8 @@ This is the opposite of creating a local copy. The file exists as a full copy in
 
 . Select the folder containing the file that is a local copy of which you want to have a _placeholder_.
 . Select the context menu for the file by doing a btn:[right click].
-. To create a _Placehholder_ file, use the action btn:[Free up space].
-. When the placeholder has been created, the icon in the btn:[Status] column changes to _Placehholder_.
+. To create a _Placeholder_ file, use the action btn:[Free up space].
+. When the placeholder has been created, the icon in the btn:[Status] column changes to _Placeholder_.
 
 +
 ifeval::["{targetbuild}" == "oc"]

--- a/modules/ROOT/pages/web_app.adoc
+++ b/modules/ROOT/pages/web_app.adoc
@@ -16,7 +16,7 @@ When more than one person is working on the same document and using a locally in
 == Prerequisite
 
 * The user only needs to have a browser installed. No settings need to be made in the Desktop App.
-* The the backend, needs to have been configured accordingly with web apps enabled. The administrator can configure the system for multiple or only particular office file types if available. If web apps are not configured and enabled for all available or particular file types, the functionality is either not available in the context menu at all or only for the configured ones. Contact your administrator for more details.
+* The backend needs to have been configured accordingly with web apps enabled. The administrator can configure the system for multiple or only particular office file types if available. If web apps are not configured and enabled for all available or particular file types, the functionality is either not available in the context menu at all or only for the configured ones. Contact your administrator for more details.
 
 == Open Files via Office Web Apps
 


### PR DESCRIPTION
## Summary

A copy-editing pass over the documentation prose, fixing spelling, typos, doubled words, and a few small grammar/clarity issues. No content meaning or markup-behavior changes.

### Typos / spelling
- `index.adoc` — "Compatiblility" → "Compatibility"
- `using.adoc` — "availabe" → "available"; "syncronization" → "synchronization"; "resoures" → "resources"; image alt-text "Synbol" → "Symbol" (×4) and "Ingnored" → "Ignored" (×2)
- `installing.adoc` — image alt-text "Start Menue" → "Start Menu" (×2)
- `troubleshooting.adoc` — "synchroinize" → "synchronize"; image alt-text "CLog files to keep" → "Log files to keep" (×2)
- `filenames.adoc` — wrong character `can´t` (acute accent) → `can't`
- `vfs.adoc` — "synchrinozation.." → "synchronization."; "Placehholder" → "Placeholder" (×3)
- `removing.adoc` — "opperating" → "operating"

### Doubled words / grammar
- `using.adoc` — "a paused sync operations" → "operation"
- `installing.adoc` — "Now, the the `Desktop.ini`" → "Now, the `Desktop.ini`"
- `troubleshooting.adoc` — "retained across restarts of the Desktop App restarts." → drop trailing "restarts"
- `filenames.adoc` — "indicating that indicates that the file" → "indicating that the file"
- `web_app.adoc` — "The the backend, needs to" → "The backend needs to"
- `automatic_updater.adoc` — "macOS Linux users" → "macOS and Linux users"

### Minor clarity / consistency
- `conflicts.adoc` — "Desktop app" → "Desktop App" (consistency)
- `vfs.adoc` — parenthesize the file-statuses list; drop a duplicated "for more details"
- `faq.adoc` — tighten "changes the mtime of the files" → "changes their modification times"
- `filenames.adoc` — reword "put on top of this document to highlight"; "likely to get problems" → "likely to cause problems"

### Notes
These were verified against the rendered prose; American/British spelling mixing (e.g. "Synchronisation"/"behaviour") was left intentionally untouched as it is used consistently in the project. A companion PR will port these fixes to the `7.1` branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)