### PR TITLE
docs: remove broken force-upload xref

### DIFF
--- a/modules/ROOT/pages/conflicts.adoc
+++ b/modules/ROOT/pages/conflicts.adoc
@@ -17,7 +17,7 @@ When you try to upload your local changes, the Desktop App will notice that the 
 * `mydata.txt` containing "_remote contents_".
 * `mydata (conflicted copy 2025-04-10 093612).txt` containing "_local contents_".
 
-In this situation, the `mydata.txt` file has the remote changes and will continue to be updated with further remote changes as they occur. Your local changes have not been sent to the server unless you have enabled xref:force-uploading-conflicted-files[Force Uploading Conflicted Files].
+In this situation, the `mydata.txt` file has the remote changes and will continue to be updated with further remote changes as they occur. Your local changes have not been sent to the server.
 
 ////
 [.yellow]#we need to solve this#


### PR DESCRIPTION
## What

Removes the dangling `xref:force-uploading-conflicted-files[Force Uploading Conflicted Files]` link in `conflicts.adoc:20`.

## Why

No section, heading, or explicit anchor with the id `force-uploading-conflicted-files` exists anywhere in the module, so Antora emits a "target of xref not found" warning. The feature is not documented in this branch. The sentence remains intact without the dangling link.

Closes #723

> Companion PR onto the `7.1` branch: same change applied there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)