### PR TITLE
docs: fix broken xref to Remove an Account section

### DIFF
--- a/modules/ROOT/pages/using.adoc
+++ b/modules/ROOT/pages/using.adoc
@@ -306,7 +306,7 @@ Synchronization occurs periodically, connecting to the server every few minutes.
 Allows you to open the browser instead of the File Explorer to view all the data of the connected account.
 
 ** menu:Remove[] +
-Lets you remove an account. See the xref:removing-an-account[Removing an Account] section below for details.
+Lets you remove an account. See the xref:remove-an-account[Removing an Account] section below for details.
 
 ==== Add New Accounts
 


### PR DESCRIPTION
## What

Fixes the broken xref at `using.adoc:309`: `removing-an-account` → `remove-an-account`.

## Why

The target heading `==== Remove an Account` (`using.adoc:315`) generates the anchor `remove-an-account` under Antora's id settings (`idprefix=''`, `idseparator='-'`), not `removing-an-account`. The previous xref did not resolve.

Closes #725

> Companion PR onto the `7.1` branch: same change applied there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)