### PR TITLE
docs: use direct same-page xref for Ignored Files Editor (7.1)

### DIFF
--- a/modules/ROOT/pages/using.adoc
+++ b/modules/ROOT/pages/using.adoc
@@ -627,7 +627,7 @@ By default, the Desktop App ignores the following files:
 ** Files with a trailing space or dot.
 ** See the xref:filenames.adoc[Filename Considerations] page to identify characters not allowed in filenames or filenames that contain reserved names that do not work on typical Windows filesystems.
 
-If a pattern selected using a checkbox in the xref:navigating.adoc#using-the-ignored-files-editor[Ignored Files Editor], or if a line in the exclude file starts with the character `]` directly followed by the file pattern, files matching the pattern are considered.
+If a pattern selected using a checkbox in the xref:using-the-ignored-files-editor[Ignored Files Editor], or if a line in the exclude file starts with the character `]` directly followed by the file pattern, files matching the pattern are considered.
 
 Fleeting meta data::
 +


### PR DESCRIPTION
## What

Replaces the alias-routed xref at `using.adoc:630` with a direct same-page xref: `navigating.adoc#using-the-ignored-files-editor` → `using-the-ignored-files-editor`.

## Why

`navigating.adoc` is only a `page-aliases` entry **of `using.adoc` itself**, so this was a same-page link routed through the page's own alias — brittle and inconsistent. The target heading `==== Using the Ignored Files Editor` (`using.adoc:570`) exists. This matches the existing correct same-page xref at `using.adoc:538`.

Refs #727 (master PR carries the closing keyword).

🤖 Generated with [Claude Code](https://claude.com/claude-code)