### PR TITLE
docs: remove stale 100-subdirectories sync-depth FAQ (7.1)

### DIFF
--- a/modules/ROOT/pages/faq.adoc
+++ b/modules/ROOT/pages/faq.adoc
@@ -75,10 +75,6 @@ If you have files with an `.eml` extension (Windows Mail, Windows Live Mail), th
 `\HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\`
 `CurrentVersion\PropertySystem\PropertyHandlers`
 
-=== Sync Stops When Trying to Sync Deeper Than 100 Subdirectories
-
-The Desktop App has been intentionally limited to sync no deeper than 100 subdirectories. The hard limit exists to protect against cyclic bugs like symbolic link loops. If a deeply nested directory is excluded from sync, it will be listed with other ignored files and directories in the menu:Activity[Not Synced] pane.
-
 ifeval::["{targetbuild}" == "oc"]
 === My Sync Folder Displays a Different Quota Than the Web Interface
 


### PR DESCRIPTION
## What

Removes the FAQ section *"Sync Stops When Trying to Sync Deeper Than 100 Subdirectories"* from `faq.adoc`.

## Why

The claimed hard limit of 100 subdirectories is stale for 7.1. Verified against the `owncloud/client` **v7.1.0** source:

- `CSYNC_STATUS_INDIVIDUAL_TOO_DEEP` (`src/csync/csync.h:85`) is **declared but never set** anywhere in `src/`.
- There is **no `MAX_DEPTH` constant** in the codebase.

The depth limit no longer exists, so the FAQ entry is removed rather than corrected.

Refs #728 (master PR carries the closing keyword).

🤖 Generated with [Claude Code](https://claude.com/claude-code)