### PR TITLE
docs: remove stale log-window keyboard shortcut

### DIFF
--- a/modules/ROOT/pages/troubleshooting.adoc
+++ b/modules/ROOT/pages/troubleshooting.adoc
@@ -92,9 +92,7 @@ Desktop App log files contain file and folder names, metadata, server URLs, and 
 ==== Logging to a Temporary Directory
 
 . Open the Desktop App.
-. Either +
-click menu:Settings[Advanced > Log Settings] or +
-press btn:[F12] (Windows) or btn:[Ctrl-L] (Linux) or btn:[Cmd+L] (macOS) on your keyboard.
+. Click menu:Settings[Advanced > Log Settings].
 +
 The Log Output window opens.
 +


### PR DESCRIPTION
## What

Removes the `btn:[F12]` / `Ctrl-L` / `Cmd+L` keyboard-shortcut instruction from the "Logging to a Temporary Directory" steps in `troubleshooting.adoc`, keeping only the menu path.

## Why

The hotkey to open the log window no longer exists. Verified against the `owncloud/client` **v7.1.0** source: the log browser is opened **only** via the General Settings "Log Settings" button (`src/gui/generalsettings.cpp:79` → `slotToggleLogBrowser`); no `F12` / `Ctrl+L` / `Cmd+L` shortcut is bound anywhere in `src/`.

Closes #597

> Companion PR onto the `7.1` branch: same change applied there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)