### PR TITLE
docs: normalize legacy server product name to "ownCloud Classic" (5.3)

### DIFF
--- a/modules/ROOT/pages/advanced_usage/command_line_client.adoc
+++ b/modules/ROOT/pages/advanced_usage/command_line_client.adoc
@@ -100,7 +100,7 @@ The following options are supported by `owncloudcmd`:
 
 == Credential Handling
 
-`owncloudcmd` requires the user to specify the username and password using the standard URL pattern. The example is based on Linux and uses ownCloud Server as backend:
+`owncloudcmd` requires the user to specify the username and password using the standard URL pattern. The example is based on Linux and uses ownCloud Classic as backend:
 
 [source,bash]
 ----

--- a/modules/ROOT/pages/appendices/architecture.adoc
+++ b/modules/ROOT/pages/appendices/architecture.adoc
@@ -59,7 +59,7 @@ The following table outlines the different synchronization methods used, dependi
 |4.5 or later |1.1 or later |File ID, Time Stamp
 |==================================================
 
-We strongly recommend using ownCloud Server release 4.5 or later when using ownCloud Desktop App 1.1 or later. Using an incompatible time stamp-based synchronization mechanism can lead to data loss in rare cases, especially when multiple Desktop Apps are involved and one utilizes a non-synchronized NTP time.
+We strongly recommend using ownCloud Classic release 4.5 or later when using ownCloud Desktop App 1.1 or later. Using an incompatible time stamp-based synchronization mechanism can lead to data loss in rare cases, especially when multiple Desktop Apps are involved and one utilizes a non-synchronized NTP time.
 
 == Comparison and Conflict Cases
 
@@ -77,7 +77,7 @@ Conflict files are always created on the Desktop App and never on the server.
 
 == Checksum Algorithm Negotiation
 
-In ownCloud 10.0 we implemented a checksum feature which checks the file integrity on upload and download by computing a checksum after the file transfer finishes. The Desktop App queries the server capabilities after login to decide which checksum algorithm to use. Currently, SHA1 is hard-coded in the official server release and can't be changed by the end-user. Note that the server additionally also supports *MD5* and *Adler-32*, but the Desktop App will always use the checksum algorithm announced in the capabilities:
+In ownCloud Classic 10.0 we implemented a checksum feature which checks the file integrity on upload and download by computing a checksum after the file transfer finishes. The Desktop App queries the server capabilities after login to decide which checksum algorithm to use. Currently, SHA1 is hard-coded in the official server release and can't be changed by the end-user. Note that the server additionally also supports *MD5* and *Adler-32*, but the Desktop App will always use the checksum algorithm announced in the capabilities:
 
 [source]
 ----

--- a/modules/ROOT/pages/appendices/troubleshooting.adoc
+++ b/modules/ROOT/pages/appendices/troubleshooting.adoc
@@ -21,11 +21,11 @@ The following two general issues can result in failed synchronization:
 
 == Identifying Basic Functionality Problems
 
-Performing a general ownCloud Server test::
+Performing a general ownCloud Classic test::
   The first step in troubleshooting synchronization issues is to verify that you can log on to the ownCloud web application. To verify connectivity to the ownCloud server try logging in via your Web browser. If you are not prompted for your username and password, or if a red warning box appears on the page, your server setup requires modification. Please verify that your server installation is working correctly.
 
 Ensure the WebDAV API is working::
-  If all Desktop Apps fail to connect to the ownCloud Server, but access using the Web interface functions properly, the problem is often a misconfiguration of the WebDAV API. The ownCloud Desktop App uses the built-in WebDAV access of the server content. Verify that you can log on to ownCloud's WebDAV server. To verify connectivity with the ownCloud WebDAV server, open a browser window and enter the address to the ownCloud WebDAV server. For example, if your ownCloud instance is installed at `\https://yourserver.com/owncloud`, your WebDAV server address is `\https://yourserver.com/owncloud/remote.php/webdav`. If you are prompted for your username and password but, after providing the correct credentials, authentication fails, please ensure that your authentication backend is configured properly.
+  If all Desktop Apps fail to connect to the ownCloud Classic server, but access using the Web interface functions properly, the problem is often a misconfiguration of the WebDAV API. The ownCloud Desktop App uses the built-in WebDAV access of the server content. Verify that you can log on to ownCloud's WebDAV server. To verify connectivity with the ownCloud WebDAV server, open a browser window and enter the address to the ownCloud WebDAV server. For example, if your ownCloud instance is installed at `\https://yourserver.com/owncloud`, your WebDAV server address is `\https://yourserver.com/owncloud/remote.php/webdav`. If you are prompted for your username and password but, after providing the correct credentials, authentication fails, please ensure that your authentication backend is configured properly.
 
 Use a WebDAV command line tool to test::
   A more sophisticated test method for troubleshooting synchronization issues is to use a WebDAV command line client and log into the ownCloud WebDAV server. One such command line client -- called `cadaver` -- is available for Linux distributions. You can use this application to further verify that the WebDAV server is running properly using PROPFIND calls. As an example, after installing the `cadaver` app, you can issue the `propget` command to obtain various properties pertaining to the current directory and also verify WebDAV server connection.
@@ -251,7 +251,7 @@ a| image::appendices/troubleshooting/log-install-macos1.png[macOS Installer Enab
 a| image::appendices/troubleshooting/log-install-macos2.png[macOS Installer Log View,width=400]
 |===
 
-=== ownCloud Server Log File
+=== ownCloud Classic Log File
 
 The ownCloud server also maintains an ownCloud specific log file. This log file must be enabled through the ownCloud Administration page. On that page, you can adjust the log level. We recommend that when setting the log file level that you set it to a verbose level like `Debug` or `Info`.
 

--- a/modules/ROOT/pages/faq.adoc
+++ b/modules/ROOT/pages/faq.adoc
@@ -28,15 +28,15 @@ Without claim of completeness, actuality or support, Windows Server releases tha
 
 === How to Interpret Quotas
 
-When a quota has been defined, either as general value in ownCloud Server or in Infinite Scale at the personal space or on a project space, you can see additional info in your sync relationship about the quota values. If no quota has been set, these values are not shown for the particular sync relationship:
+When a quota has been defined, either as general value in ownCloud Classic or in Infinite Scale at the personal space or on a project space, you can see additional info in your sync relationship about the quota values. If no quota has been set, these values are not shown for the particular sync relationship:
 
 [width=100%,cols="^.50%,^.50%",options="header"]
 |===
-a| ownCloud Server +
+a| ownCloud Classic +
 Quotas shown for the sync relationship
 a| Infinite Scale +
 No quotas shown for the personal space or received shares, but for project spaces
-a| image::faq/sync-quota-oc10.png[Quotas in ownCloud Server,width=350]
+a| image::faq/sync-quota-oc10.png[Quotas in ownCloud Classic,width=350]
 a| image::faq/sync-quota-spaces.png[Quotas in Infinite Scale,width=350]
 |===
 
@@ -53,10 +53,10 @@ a|
   *Data used in my quota*
 
 + data used in external storages (a)
-  (ownCloud Server only)
+  (ownCloud Classic only)
 
 + data used in other users' shares (a)
-  (ownCloud Server only)
+  (ownCloud Classic only)
 
 = *Total used in my quota*
 ----
@@ -67,17 +67,17 @@ a|
   *Available quota*
 
 + data used in external storages (a)
-  (ownCloud Server only)
+  (ownCloud Classic only)
 
 + data used in other users' shares (a)
-  (ownCloud Server only)
+  (ownCloud Classic only)
 
 = *Total available in my quota*
 ----
 |===
 
 .Note to reference (a) in the table
-ownCloud Server provides external storages and remote shares as folders. These folders do not count against the quota. To mitigate this situation in the Desktop app, the sizes of these folders are added to the quotas shown by the Desktop app automatically to avoid showing incorrect available space. In total, the quota values level out and no wrong differences are shown, though the absolute quota values may look higher than they are in reality - the absolute difference is correct. This difference shows if files to sync could be uploaded to the server successfully.
+ownCloud Classic provides external storages and remote shares as folders. These folders do not count against the quota. To mitigate this situation in the Desktop app, the sizes of these folders are added to the quotas shown by the Desktop app automatically to avoid showing incorrect available space. In total, the quota values level out and no wrong differences are shown, though the absolute quota values may look higher than they are in reality - the absolute difference is correct. This difference shows if files to sync could be uploaded to the server successfully.
 
 Note that with Infinite Scale, each space has its own sync relationship and therefore quota values show as they are defined for each.
 
@@ -172,7 +172,7 @@ The ownCloud Desktop App talks to a server, e.g. the ownCloud server, so you do 
 
 image::faq/oc-unsupported-version-warning-message.png[image, width=350,pdfwidth=60%]
 
-Only ownCloud 10.0.0 or Higher Is Supported::
+Only ownCloud Classic 10.0.0 or Higher Is Supported::
 If you encounter such a message, you should ask your administrator to upgrade ownCloud to a secure version because earlier versions are not maintained anymore. An important feature of the ownCloud Desktop App is checksumming – each time you download or upload a file, the Desktop App and the server both check if the file was corrupted during the sync. This way you can be sure that you don’t lose any files.
 +
 There are servers out there which don’t have checksumming implemented on their side, or which are not tested by ownCloud’s QA team. They can’t ensure file integrity, they have potential security issues, and we can’t guarantee that they are compatible with the ownCloud Desktop App.

--- a/modules/ROOT/pages/using.adoc
+++ b/modules/ROOT/pages/using.adoc
@@ -92,7 +92,7 @@ image:using/wizard-screen-url.png[form for entering ownCloud instance URL, width
 --
 [NOTE]
 ====
-To use *Two-Factor Authentication* (2FA) with the ownCloud Server backend, ownCloud Server must have the {oauth2-app-url}[OAuth2 app] installed, configured and enabled. Please contact your ownCloud administrator for more details.
+To use *Two-Factor Authentication* (2FA) with the ownCloud Classic backend, ownCloud Classic must have the {oauth2-app-url}[OAuth2 app] installed, configured and enabled. Please contact your ownCloud administrator for more details.
 ====
 
 [width=100%,cols="^.^50%,^.^50%"]
@@ -185,7 +185,7 @@ image::using/account-force-sync-now.png[Force Sync Now, width=350,pdfwidth=60%]
 
 === Spaces
 
-Spaces are only available when connected to an Infinite Scale backend. In most cases, they are similar to folders or external mounts when the backend is ownCloud Server and one might not see differences, though some exist:
+Spaces are only available when connected to an Infinite Scale backend. In most cases, they are similar to folders or external mounts when the backend is ownCloud Classic and one might not see differences, though some exist:
 
 * On initial account setup, all available spaces are auto-selected for the synchronization process.
 ** There are at minimum two spaces added, which are the personal space and the space that contains all received shares. Shares are shown as folders in the local filesystem.
@@ -197,13 +197,13 @@ Spaces are only available when connected to an Infinite Scale backend. In most c
 
 === Managing Resources to Synchronize
 
-When an account gets added the first time, you can select which remote resources you want to synchronize. This includes the syncronization type which defaults to VFS if available on your operating system (OS) or selective sync where you manually select the resoures to be synchronized otherwise. These resources are represented by the Desktop app as local folders using the base path defined during account setup. Depending on the backend connected, resources shown can be the full external mount or a folder inside an external mount when using ownCloud Server, or spaces when using Infinite Scale.
+When an account gets added the first time, you can select which remote resources you want to synchronize. This includes the syncronization type which defaults to VFS if available on your operating system (OS) or selective sync where you manually select the resoures to be synchronized otherwise. These resources are represented by the Desktop app as local folders using the base path defined during account setup. Depending on the backend connected, resources shown can be the full external mount or a folder inside an external mount when using ownCloud Classic, or spaces when using Infinite Scale.
 
 If VFS is available for your OS but selective sync has been chosen, you can at any time switch to VFS and vice versa. Note to check the available disk space before switching from VFS to selective sync (Disable Virtual File support). 
 
 The base path defined on first sync is not the only path that can be used. Resources can have their individual base path. This is can be beneficial if you want selected resources to be located on different paths than the default.
 
-==== Using an Account That Connects To ownCloud Server:
+==== Using an Account That Connects To ownCloud Classic:
 
 When VFS has been enabled on initial account setup, all new resources from the server will be added automatically but do not require additional space.
 
@@ -260,10 +260,10 @@ image:using/owncloud-share.png[Sharing Context Menu, width=350,pdfwidth=70%]
 +
 The default browser opens and shows the share dialog of ownCloud Web to take the required settings. If you are not logged in, you will be asked to do so first.
 
-** *ownCloud Server*
+** *ownCloud Classic*
 +
 --
-The share dialog opens which has all the same options as your ownCloud Server Web interface.
+The share dialog opens which has all the same options as your ownCloud Classic Web interface.
 
 [width=100%,cols="^.50%,^.50%",options="header"]
 |===

--- a/modules/ROOT/pages/web_app.adoc
+++ b/modules/ROOT/pages/web_app.adoc
@@ -14,7 +14,7 @@ When more than one person is working on the same document and using a locally in
 == Prerequisite
 
 * The user only needs to have a browser installed. No settings need to be made in the Desktop App.
-* The the backend, which is either Infinite Scale or ownCloud Server needs to have been configured accordingly with web apps enabled. The administrator can configure the system for multiple or only particular office file types if available. If web apps are not configured and enabled for all available or particular file types, the functionality is either not available in the context menu at all or only for the configured ones. Contact your administrator for more details.
+* The the backend, which is either Infinite Scale or ownCloud Classic needs to have been configured accordingly with web apps enabled. The administrator can configure the system for multiple or only particular office file types if available. If web apps are not configured and enabled for all available or particular file types, the functionality is either not available in the context menu at all or only for the configured ones. Contact your administrator for more details.
 
 == Open Files via Office Web Apps
 


### PR DESCRIPTION
## What

Normalizes the legacy ownCloud server product to its canonical name **ownCloud Classic** across all user-facing documentation in this repo. Version (10/11) is retained only as trailing information where relevant (e.g. "ownCloud Classic 10").

Normalized: `ownCloud Server`, `owncloud Server`, `ownCloud Classic Server`, and bare `ownCloud 10/11`.

## Why

Part of owncloud/docs#5111 — a coordinated, docs-only rebranding so the legacy product is consistently named **ownCloud Classic** across the `owncloud` / `owncloud-docker` orgs. Reference implementation: owncloud/docs-main#187.

## Out of scope (intentionally untouched)

- `xref:`/`include::` targets, module slugs (`classic_ui`, `oc10-app`), URLs, attribute names (e.g. `oc10-api-url`), image paths, anchors
- The new product names: **ownCloud Infinite Scale** / **oCIS**

## Verification

- All target variants normalized; only prose / headings / link display text changed.
- Every `xref`/`include`/URL **target** byte-for-byte identical before/after.
- `oCIS` / `Infinite Scale` occurrence count unchanged.
- No internal xref depends on any heading whose auto-generated anchor changes.

## Reviewer checklist

- [ ] No xref targets / module slugs / URLs altered
- [ ] oCIS / Infinite Scale untouched
- [ ] Version shown only as additional info ("ownCloud Classic 10")

🤖 Generated with [Claude Code](https://claude.com/claude-code)
