### PR TITLE
docs: normalize legacy server product name to "ownCloud Classic" (6.0)

### DIFF
--- a/modules/ROOT/pages/advanced_usage/command_line_client.adoc
+++ b/modules/ROOT/pages/advanced_usage/command_line_client.adoc
@@ -104,7 +104,7 @@ The following options are supported by `{bin_name}cmd`:
 
 `{bin_name}cmd` requires the user to specify the username and password using the standard URL pattern.
 ifeval::["{targetbuild}" == "oc"]
-The example is based on Linux and uses ownCloud Server as backend:
+The example is based on Linux and uses ownCloud Classic as backend:
 endif::[]
 
 [source,bash,subs="attributes+,macros+"]

--- a/modules/ROOT/pages/faq.adoc
+++ b/modules/ROOT/pages/faq.adoc
@@ -31,11 +31,11 @@ When a quota has been defined, you can see additional info in your sync relation
 
 [width=100%,cols="^.50%,^.50%",options="header"]
 |===
-a| ownCloud Server +
+a| ownCloud Classic +
 Quotas shown for the sync relationship
 a| Infinite Scale +
 No quotas shown for the personal space or received shares, but for project spaces
-a| image::faq/sync-quota-oc10.png[Quotas in ownCloud Server,width=350]
+a| image::faq/sync-quota-oc10.png[Quotas in ownCloud Classic,width=350]
 a| image::faq/sync-quota-spaces.png[Quotas in Infinite Scale,width=350]
 |===
 
@@ -52,10 +52,10 @@ a|
   *Data used in my quota*
 
 + data used in external storages (a)
-  (ownCloud Server only)
+  (ownCloud Classic only)
 
 + data used in other users' shares (a)
-  (ownCloud Server only)
+  (ownCloud Classic only)
 
 = *Total used in my quota*
 ----
@@ -66,17 +66,17 @@ a|
   *Available quota*
 
 + data used in external storages (a)
-  (ownCloud Server only)
+  (ownCloud Classic only)
 
 + data used in other users' shares (a)
-  (ownCloud Server only)
+  (ownCloud Classic only)
 
 = *Total available in my quota*
 ----
 |===
 
 .Note to reference (a) in the table
-ownCloud Server provides external storages and remote shares as folders. These folders do not count against the quota. To mitigate this situation in the Desktop app, the sizes of these folders are added to the quotas shown by the Desktop app automatically to avoid showing incorrect available space. In total, the quota values level out and no wrong differences are shown, though the absolute quota values may look higher than they are in reality - the absolute difference is correct. This difference shows if files to sync could be uploaded to the server successfully.
+ownCloud Classic provides external storages and remote shares as folders. These folders do not count against the quota. To mitigate this situation in the Desktop app, the sizes of these folders are added to the quotas shown by the Desktop app automatically to avoid showing incorrect available space. In total, the quota values level out and no wrong differences are shown, though the absolute quota values may look higher than they are in reality - the absolute difference is correct. This difference shows if files to sync could be uploaded to the server successfully.
 
 Note that with Infinite Scale, each space has its own sync relationship and therefore quota values show as they are defined for each.
 endif::[]

--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -11,7 +11,7 @@ include::partial$conditional_naming.adoc[]
 
 == Compatiblility
 
-NOTE: Starting with {ini_name} version 7.0, the Desktop App will no longer support ownCloud Server, only ownCloud Infinite Scale. To use the Desktop App with ownCloud Server, use version 6.x instead.
+NOTE: Starting with {ini_name} version 7.0, the Desktop App will no longer support ownCloud Classic, only ownCloud Infinite Scale. To use the Desktop App with ownCloud Classic, use version 6.x instead.
 
 == Key Benefits
 

--- a/modules/ROOT/pages/using.adoc
+++ b/modules/ROOT/pages/using.adoc
@@ -391,7 +391,7 @@ Note that if you create a new sync connection for the previously removed folder,
 ifeval::["{targetbuild}" == "oc"]
 === Spaces
 
-Spaces are only available when connected to an Infinite Scale backend. In most cases, they are similar to folders or external mounts when the backend is ownCloud Server and one might not see differences, though some exist:
+Spaces are only available when connected to an Infinite Scale backend. In most cases, they are similar to folders or external mounts when the backend is ownCloud Classic and one might not see differences, though some exist:
 
 * On initial account setup, all available spaces are auto-selected for the synchronization process.
 ** There are at minimum two spaces added, which are the personal space and the space that contains all received shares. Shares are shown as folders in the local filesystem.
@@ -403,13 +403,13 @@ Spaces are only available when connected to an Infinite Scale backend. In most c
 
 === Managing Resources to Synchronize
 
-When an account gets added the first time, you can select which remote resources you want to synchronize. This includes the syncronization type which defaults to VFS if available on your operating system (OS) or selective sync where you manually select the resoures to be synchronized otherwise. These resources are represented by the Desktop app as local folders using the base path defined during account setup. Depending on the backend connected, resources shown can be the full external mount or a folder inside an external mount when using ownCloud Server, or spaces when using Infinite Scale.
+When an account gets added the first time, you can select which remote resources you want to synchronize. This includes the syncronization type which defaults to VFS if available on your operating system (OS) or selective sync where you manually select the resoures to be synchronized otherwise. These resources are represented by the Desktop app as local folders using the base path defined during account setup. Depending on the backend connected, resources shown can be the full external mount or a folder inside an external mount when using ownCloud Classic, or spaces when using Infinite Scale.
 
 If VFS is available for your OS but selective sync has been chosen, you can at any time switch to VFS and vice versa. Note to check the available disk space before switching from VFS to selective sync (Disable Virtual File support). 
 
 The base path defined on first sync is not the only path that can be used. Resources can have their individual base path. This is can be beneficial if you want selected resources to be located on different paths than the default.
 
-==== Using an Account That Connects To ownCloud Server:
+==== Using an Account That Connects To ownCloud Classic:
 
 When VFS has been enabled on initial account setup, all new resources from the server will be added automatically but do not require additional space.
 
@@ -475,10 +475,10 @@ image:using/owncloud-share.png[Sharing Context Menu, width=100]
 +
 The default browser opens and shows the share dialog of ownCloud Web to take the required settings. If you are not logged in, you will be asked to do so first.
 
-** *ownCloud Server*
+** *ownCloud Classic*
 +
 --
-The share dialog opens which has all the same options as your ownCloud Server Web interface.
+The share dialog opens which has all the same options as your ownCloud Classic Web interface.
 
 [width=100%,cols="^.50%,^.50%",options="header"]
 |===
@@ -526,7 +526,7 @@ In any of the activity tabs you can mark a single line, multiple lines or all li
 ifeval::["{targetbuild}" == "oc"]
 === Server Notifications
 
-For ownCloud Server only, the Desktop App will display notifications from your {ini_name} server that require manual interaction. It automatically checks for available notifications automatically on a regular basis. Notifications are displayed in the Server Activity tab. If you have enabled menu:Settings[General Settings > Show Desktop Notifications] you'll also see a systray notification.
+For ownCloud Classic only, the Desktop App will display notifications from your {ini_name} server that require manual interaction. It automatically checks for available notifications automatically on a regular basis. Notifications are displayed in the Server Activity tab. If you have enabled menu:Settings[General Settings > Show Desktop Notifications] you'll also see a systray notification.
 
 For example, when a user on a remote ownCloud creates a new Federated share for you, you can accept it from your desktop client. This also displays notifications sent to users by the ownCloud admin via the Announcements app.
 


### PR DESCRIPTION
## What

Normalizes the legacy ownCloud server product to its canonical name **ownCloud Classic** across all user-facing documentation in this repo. Version (10/11) is retained only as trailing information where relevant (e.g. "ownCloud Classic 10").

Normalized: `ownCloud Server`, `owncloud Server`, `ownCloud Classic Server`, and bare `ownCloud 10/11`.

## Why

Part of owncloud/docs#5111 — a coordinated, docs-only rebranding so the legacy product is consistently named **ownCloud Classic** across the `owncloud` / `owncloud-docker` orgs. Reference implementation: owncloud/docs-main#187.

## Out of scope (intentionally untouched)

- `xref:`/`include::` targets, module slugs (`classic_ui`, `oc10-app`), URLs, attribute names (e.g. `oc10-api-url`), image paths, anchors
- The new product names: **ownCloud Infinite Scale** / **oCIS**

## Verification

- All target variants normalized; only prose / headings / link display text changed.
- Every `xref`/`include`/URL **target** byte-for-byte identical before/after.
- `oCIS` / `Infinite Scale` occurrence count unchanged.
- No internal xref depends on any heading whose auto-generated anchor changes.

## Reviewer checklist

- [ ] No xref targets / module slugs / URLs altered
- [ ] oCIS / Infinite Scale untouched
- [ ] Version shown only as additional info ("ownCloud Classic 10")

🤖 Generated with [Claude Code](https://claude.com/claude-code)
