### PR TITLE
docs: fix Activity window tabs for oc (7.1)

### DIFF
--- a/modules/ROOT/pages/using.adoc
+++ b/modules/ROOT/pages/using.adoc
@@ -481,11 +481,9 @@ The Activity window contains the log of your recent activities, organized in the
 ifeval::["{targetbuild}" == "oc"]
 image::using/oc-windows-activity-pane-server.png[Activity Pane, width=100]
 
-* Server Activities: +
-Includes new shares and downloaded and deleted files
-
-* Sync Protocol: +
-Shows local activity, such as which local folders your files have gone to.
+* Local Activity: +
+Includes files uploaded, downloaded or deleted. +
+Note that menu:mouse[right click] opens a menu for more actions.
 endif::[]
 
 ifeval::["{targetbuild}" == "kw"]


### PR DESCRIPTION
## Summary

The oc-brand Activity Window section documents two tabs — **Server Activities** and **Sync Protocol** — that do not exist in client 7.1. The Activity widget creates exactly two tabs: **Local Activity** (`tr("Local Activity")`) and **Not Synced** (`tr("Not Synced")`).

This PR replaces the two fictional oc tabs with the real **Local Activity** tab description (aligning with the already-correct kw block). The shared **Not Synced** bullet below the `ifeval` blocks is unchanged.

> Note: the screenshot `using/oc-windows-activity-pane-server.png` still depicts the old layout and is flagged for recapture in the audit follow-up.

## Source of truth

`owncloud/client` @ `7.1`: `src/gui/activitysettings.cpp:37-40`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)