### PR TITLE
docs: fix Activity window tabs for oc

### DIFF
--- a/modules/ROOT/pages/using.adoc
+++ b/modules/ROOT/pages/using.adoc
@@ -481,11 +481,9 @@ The Activity window contains the log of your recent activities, organized in the
 ifeval::["{targetbuild}" == "oc"]
 image::using/oc-windows-activity-pane-server.png[Activity Pane, width=100]
 
-* Server Activities: +
-Includes new shares and downloaded and deleted files
-
-* Sync Protocol: +
-Shows local activity, such as which local folders your files have gone to.
+* Local Activity: +
+Includes files uploaded, downloaded or deleted. +
+Note that menu:mouse[right click] opens a menu for more actions.
 endif::[]
 
 ifeval::["{targetbuild}" == "kw"]


### PR DESCRIPTION
master counterpart of #755. The oc Activity window documents non-existent "Server Activities"/"Sync Protocol" tabs; client 7.1 has only "Local Activity" + "Not Synced" (`src/gui/activitysettings.cpp:37-40`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)