### PR TITLE
docs: complete folder three-dots menu for oc (7.1)

### DIFF
--- a/modules/ROOT/pages/using.adoc
+++ b/modules/ROOT/pages/using.adoc
@@ -391,8 +391,26 @@ See the section xref:remove-sync-relationships[Remove Sync Relationships] below 
 endif::[]
 
 ifeval::["{targetbuild}" == "oc"]
-** menu:Enable virtual file support[] / menu:Disable virtual file support[] +
-Enable or disable virtual file support for this sync relationship, if supported by the operating system.
+** menu:Show in Explorer[] +
+Opens your local {ini_name} sync folder for this sync relationship. +
+(Note that the name `Explorer` is replaced by the name of the file browser of your operating system.)
+
+** menu:Show in web browser[] +
+Opens {ini_name} via the browser. +
+(This entry is only available if the server supports private links.)
+
+** menu:Sync now[] / menu:Restart sync[] +
+Synchronizes this sync relationship immediately. While a sync is running, the entry is labeled menu:Restart sync[].
+
+** menu:Pause sync[] / menu:Resume sync[] +
+Pauses or resumes synchronization for this sync relationship.
+
+** menu:Activate virtual files[] / menu:Deactivate virtual files[] +
+Activates or deactivates virtual file support for this sync relationship, if supported by the operating system. +
+(When virtual files are not enabled, this entry is replaced by menu:Manage subfolder sync[], which lets you choose which subfolders to synchronize.)
+
+** menu:Remove folder sync[] +
+Removes this sync relationship. For a Space, the entry is labeled menu:Remove Space sync[]. See the section xref:remove-sync-relationships[Remove Sync Relationships] below for details.
 endif::[]
 
 === Remove Sync Relationships


### PR DESCRIPTION
## Summary

The oc-brand **Manage Sync Relationships** section documents the folder *Three Dots* menu as a single entry — *Enable/Disable virtual file support* — but client 7.1 builds a much richer menu:

- **Show in Explorer** (`CommonStrings::showInFileBrowser()`)
- **Show in web browser** (only when the server supports private links)
- **Sync now** / **Restart sync**
- **Pause sync** / **Resume sync**
- **Activate virtual files** / **Deactivate virtual files** — or **Manage subfolder sync** when VFS is unavailable
- **Remove folder sync** / **Remove Space sync**

This PR rewrites the oc list to match, and corrects the VFS toggle wording (`Activate/Deactivate virtual files`, not `Enable/Disable virtual file support`).

> Note: `using/oc-windows-folder-menu.png` is flagged for recapture in the audit follow-up.

## Source of truth

`owncloud/client` @ `7.1`: `src/gui/FoldersGui/accountfolderscontroller.cpp:120-247`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)