### PR TITLE
docs: use correct owncloud.exe binary name for oc (7.1)

### DIFF
--- a/modules/ROOT/pages/removing.adoc
+++ b/modules/ROOT/pages/removing.adoc
@@ -21,7 +21,12 @@ Just delete the AppImage file.
 If you have uninstalled the {ini_name} Desktop App but still have the {ini_name} shortcut or icon in your Windows taskbar, follow these steps to remove it:
 
 1. Open `regedit`. (press the Windows Key and type: regedit)
+ifeval::["{targetbuild}" == "oc"]
+2. Search ( btn:[CTRL or STRG + F] ) for the name of the Desktop App, in this case `owncloud.exe`.
+endif::[]
+ifeval::["{targetbuild}" == "kw"]
 2. Search ( btn:[CTRL or STRG + F] ) for the name of the Desktop App, in this case `{bin_name}.exe`.
+endif::[]
 3. Press btn:[F3] for next search results.
 4. Look for the key `System.IsPinnedToNameSpaceTree`.
 5. Right-click on the key name, change, set to `0` instead of `1`.


### PR DESCRIPTION
## Summary

The *Windows Navigation Sidebar* regedit step searched for `{bin_name}.exe`, which renders as **`ownCloud.exe`** for the oc build. The actual Windows binary is **`owncloud.exe`** — `APPLICATION_EXECUTABLE` is lowercase (`OWNCLOUD.cmake`, `src/gui/CMakeLists.txt`).

The step is split with an `ifeval` so the oc variant shows `owncloud.exe` while the kw variant keeps `{bin_name}.exe` (which already renders lowercase as `kiteworks`).

> Note: regedit's *Find* is case-insensitive, so the old text still worked in practice; this corrects the documented name for accuracy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)