### PR TITLE
docs: correct OWNCLOUD_HTTP2_ENABLED default (7.1)

### DIFF
--- a/modules/ROOT/pages/advanced_usage/environment_variables.adoc
+++ b/modules/ROOT/pages/advanced_usage/environment_variables.adoc
@@ -47,8 +47,8 @@ More information available under the "Low Disk Space" section.
 | Maximum timeout, in seconds, for blacklisted files.
 
 | `OWNCLOUD_HTTP2_ENABLED`
-| depends on Qt version
-| Force-enable ("1") or force-disable ("0") HTTP2 support.
+| 0 (disabled)
+| HTTP2 is disabled by default and must be force-enabled by setting this variable to "1"; any other value leaves it disabled.
 Note that HTTP2 use also depends on whether the server supports it.
 
 | `OWNCLOUD_SQLITE_JOURNAL_MODE`


### PR DESCRIPTION
## Summary

The documented default for `OWNCLOUD_HTTP2_ENABLED` was *"depends on Qt version"*. In client 7.1 HTTP2 is **force-disabled by default**: the attribute is set to `qEnvironmentVariableIntValue("OWNCLOUD_HTTP2_ENABLED") == 1`, so anything other than `"1"` (including unset) leaves HTTP2 disabled. There is no Qt-version branching.

Updates the Default column to **`0 (disabled)`** and clarifies it must be force-enabled with `"1"` (and still requires server support).

## Source of truth

`owncloud/client` @ `7.1`: `src/libsync/accessmanager.cpp:95-98`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)